### PR TITLE
docs: document diff 2 scope

### DIFF
--- a/MODELE-DONNEES.md
+++ b/MODELE-DONNEES.md
@@ -43,3 +43,31 @@ insert into app_info (id, name) values (1, 'LOCATION') on conflict do nothing;
 ## Seeds (dev)
 - En Diff 2 : seeds cohérents insérés via migrations conditionnelles ou scripts `data-dev.sql`.  
   Diff 1 n’en a pas besoin au-delà d’`app_info`.
+
+---
+
+## (Nouveau) Schéma Diff 2
+
+### Tables principales
+- `agency(id uuid pk, name text unique not null)`
+- `client(id uuid pk, name text not null, billing_email text)`
+- `resource_type(id uuid pk, label text not null)`
+- `resource(id uuid pk, type_id uuid fk, name text not null, license_plate text unique, color_rgb int, agency_id uuid fk, visible boolean not null)`
+- `driver(id uuid pk, name text not null)`
+- `contact(id uuid pk, client_id uuid fk, name text not null, email text, phone text)`
+- `intervention(id uuid pk, agency_id uuid fk, resource_id uuid fk, client_id uuid fk, start_ts timestamp not null, end_ts timestamp not null, title text not null)`
+- `document(id uuid pk, doc_type text not null, date_ts date not null, client_id uuid fk, total_cents bigint not null)`
+
+### Index clés
+- `idx_intervention_resource_start (resource_id, start_ts)`
+- `idx_intervention_agency_start (agency_id, start_ts)`
+- `idx_resource_agency (agency_id)`
+
+### Règle métier (service)
+Conflit si **intersection non vide** entre deux interv. de **même ressource** sur `[start,end)`.
+
+### Seeds (dev)
+- 2 agences (Agence 1, Agence 2)
+- 3 clients (Alpha, Beta, Gamma)
+- 3 ressources (Camion X, Grue Y, Remorque Z)
+- 3 interventions non conflictuelles

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Base exécutable **backend Spring Boot (Java 17)** + **frontend Java Swing (FlatLaf)** avec **sélecteur de source Mock/Backend**, **SSE `/api/system/ping`**, **auth JWT `/auth/login`**, profils **dev(H2)** / **prod(Postgres)**, **Flyway**, **CI GitHub Actions**.
 
 > **Diff 1** : squelette complet + docs + CI + mode Mock fonctionnel côté client + stratégie d’injection (DataSourceProvider).
+>
+> **Diff 2** : **Modèle & API** — entités, services avec **détection de chevauchement**, endpoints **`/api/v1/**`** (agences, clients, ressources, interventions), **DTOs stables**, **validation**, **erreurs structurées**, **migrations Flyway V2+** et **seeds** (dev). **Stubs export PDF & emailing**.
 
 ## Démarrage rapide
 
@@ -18,6 +20,13 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 Le backend expose :
 - `POST /auth/login` → JWT (acceptation basique : identifiants non vides dans Diff 1)
 - `GET  /api/system/ping` → SSE (un event ~toutes 15s)
+- **API v1** (Diff 2) :
+  - `GET /api/v1/agencies`
+  - `GET /api/v1/clients`
+  - `GET /api/v1/resources`
+  - `GET /api/v1/interventions?from=...&to=...&resourceId=...`
+  - `POST /api/v1/interventions` (validation + **anti-chevauchement**)
+  - (stubs) `POST /api/v1/documents/{id}/export/pdf`, `POST /api/v1/documents/{id}/email`
 
 Variables d’env utiles :
 - `JWT_SECRET` (défaut: `dev-secret-please-change`)
@@ -76,6 +85,12 @@ Une GitHub Action build & tests Maven :
 ## Tests
 - **Server** : tests WebMvc pour `/auth/login` et SSE `/api/system/ping`.
 - **Client** : test unitaire sur la résolution du mode (argument CLI > préférences > dialogue).
+- **Diff 2** :
+  - Tests WebMvc `GET /api/v1/agencies` (200 + JSON)
+  - Test DataJpa/Service création d’intervention **en conflit** → **exception 409** (via service + contrôleur)
+
+## DTOs & Parité Mock/REST
+Le client a été mis à jour pour consommer les listes **Agences** et **Clients** depuis `/api/v1/**` en mode REST. Le **mode Mock** expose les mêmes DTOs côté client (`Models.Agency`, `Models.Client`), garantissant la compatibilité d’affichage.
 
 ## Packaging
 ```bash
@@ -94,3 +109,9 @@ Supprimer `~/.location/app.properties`.
 ---
 
 Voir : `SPEC-FONCTIONNELLE.md`, `SPEC-TECHNIQUE.md`, `MODELE-DONNEES.md` (source de vérité).
+
+## Notes Diff 2
+- **Conflits d’affectation** : deux interventions d’une **même ressource** sont en conflit si les périodes `[start,end)` se chevauchent (intersection **non vide**).
+- **Erreurs structurées** : format `application/json` : `{"timestamp": "...","status":409,"error":"Conflict","message":"...","path":"/api/v1/interventions"}`.
+- **Seeds (dev)** : 2 agences, 3 clients, 3 ressources, 2 chauffeurs, 3 interventions non conflictuelles.
+- **Exports** : endpoints présents, implémentation **stub** (retourne PDF minimal / email simulé en logs). 

--- a/SPEC-FONCTIONNELLE.md
+++ b/SPEC-FONCTIONNELLE.md
@@ -72,3 +72,45 @@ Ces structures suffisent pour **démonstration** et seront **stabilisées** en D
 
 ## Hors périmètre Diff 1 (reporté)
 - Éditeurs intégrés, planning tuiles (drag/resize/hover), exports PDF/CSV, emailing, règles de chevauchement strictes, pagination/tri côté API — **prévu** Diff 2/3.
+
+---
+
+## (Nouveau) Périmètre Diff 2 — Modèle & API
+
+### Endpoints **`/api/v1/**`**
+- `GET /agencies` : liste des agences.
+- `GET /clients` : liste des clients.
+- `GET /resources` : liste des ressources (grue/camion/remorque…).
+- `GET /interventions?from&to&resourceId` : liste filtrée par période et/ou ressource.
+- `POST /interventions` : crée une intervention **avec détection de conflits**.
+- (stubs) `POST /documents/{id}/export/pdf` : renvoie un PDF minimal (stub).
+- (stubs) `POST /documents/{id}/email` : simule l’envoi (logs).
+
+### Règles — **Chevauchement**
+Deux interventions de **même ressource** (resourceId) sont déclarées en **conflit** si :
+
+`[start, end)` **∩** `[start', end')` **≠ ∅** (intervalle demi-ouvert).
+
+→ Le service refuse la création/modification et le contrôleur renvoie **409 Conflict** avec une **erreur structurée**.
+
+### Validation
+- `start < end` ; champs obligatoires `agenceId`, `resourceId`, `clientId`, `titre` (taille ≤ 140).
+
+### Seeds (profil `dev`)
+- 2 agences, 3 clients, 3 ressources, 2 chauffeurs, 3 interventions **non conflictuelles**.
+
+### Parité Mock/REST (client)
+- En mode REST, le client consomme `/api/v1/agencies` et `/api/v1/clients`.
+- En mode Mock, même rendu via `MockDataSource`.
+
+### Erreurs structurées
+Format JSON générique :
+```json
+{
+  "timestamp": "2025-09-24T10:37:42Z",
+  "status": 409,
+  "error": "Conflict",
+  "message": "Intervention en conflit pour la ressource R-123",
+  "path": "/api/v1/interventions"
+}
+```


### PR DESCRIPTION
## Summary
- document the new Diff 2 backend/API scope in the README and specifications
- capture validation, conflict handling, and seed data expectations for the upcoming release
- outline schema updates and client parity details for API v1 resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4df1e8f9c8330a85ca884b567ddf3