### PR TITLE
Add planning filters and CSV export features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,42 +2,30 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
-## Sprint 3 — UI Swing & Intégration (Full)
+## Sprint 4 — Filtres, Navigation Jour & Export CSV REST (Full)
 
-### Ce qui arrive dans ce patch
-
-- **Planning** interactif (tuiles) par ressource (jour) avec **hover**, **drag**, **resize** (Mock actif ; REST en lecture seule pour éviter les API non disponibles).
-- **Éditeurs intégrés** : création simple d’intervention depuis le planning (Mock) et via REST (POST) si pas de conflit (lecture/écriture limitée au POST).
-- **Exports** : PDF (via endpoint REST de stub) + **CSV** local depuis le client.
-- **Login REST** : boîte de dialogue (URL + credentials), JWT géré par `RestDataSource`.
-- **Menus** :
-  - **Paramètres** → *Changer de source de données* (Mock/REST) et *Configurer le backend (URL/identifiants)*.
-  - **Données** → *Réinitialiser la démo* (Mock).
-  - **Fichier** → *Exporter planning en CSV*, *Exporter document PDF (stub)*.
-- **Accessibilité** : navigation clavier basique, contraste FlatLaf, tooltips.
-- **Erreurs & retries** : toasts non intrusifs, messages clairs (409 conflit, 400 validation).
-
-### Limitations connues (transparentes)
-- **Drag/resize** persistants uniquement en **mode Mock** (pas d’endpoint PATCH/PUT côté REST dans le périmètre Sprint 2). En mode REST, les interactions sont simulées visuellement et **non enregistrées** – un toast l’indique.
-- Export **PDF** utilise le stub `/api/v1/documents/{id}/export/pdf` (génère un mini-PDF de test).
+### Nouvelles fonctionnalités
+- **Navigation jour** (← / → et sélecteur de date) dans le planning.
+- **Filtres** : Agence, Ressource, Client, Recherche texte (titre).
+- **Export CSV côté serveur** : `GET /api/v1/interventions/csv?from&to&resourceId&clientId&q` (UTF‑8, `text/csv` avec `Content-Disposition`).
+- **Export CSV côté client** (Mock ou REST) depuis menu Fichier ou `Ctrl+E`.
+- **Préférences** : persistance des derniers filtres et de la dernière date (`~/.location/app.properties`).
+- **Accessibilité** : focus clair, raccourcis `Ctrl+←/→` pour naviguer dans les jours.
 
 ### Démarrage rapide
 ```bash
 mvn -B -ntp verify
 mvn -pl server spring-boot:run -Dspring-boot.run.profiles=dev
-# Autre terminal
+# Client
 mvn -pl client -DskipTests package && java -jar client/target/location-client.jar --datasource=mock
-# ou REST
-java -jar client/target/location-client.jar --datasource=rest
 ```
 
-### Raccourcis (client)
-- `Ctrl+N` : Nouvelle intervention (Mock ou REST via POST).
-- `Ctrl+E` : Export CSV du planning affiché.
-- `Ctrl+L` : Login/Config REST.
+### Endpoints ajoutés
+- `GET /api/v1/interventions/csv?from&to&resourceId&clientId&q` → CSV
 
-### Tests inclus
-- Tests unitaires de **layout temporel** (pixel ↔ temps), et **détection de conflits** côté Mock.
+### Tests
+- WebMvc : CSV 200 + header `attachment`.
+- UI : simple test de persistance des préférences.
 
 ## Auth & SSE
 - `POST /auth/login` → `{ "token": "..." }`

--- a/client/src/main/java/com/location/client/core/Preferences.java
+++ b/client/src/main/java/com/location/client/core/Preferences.java
@@ -71,4 +71,60 @@ public class Preferences {
   public void setRestPass(String value) {
     props.setProperty("restPass", value);
   }
+
+  public String getFilterAgencyId() {
+    return props.getProperty("filterAgencyId");
+  }
+
+  public void setFilterAgencyId(String value) {
+    if (value == null) {
+      props.remove("filterAgencyId");
+    } else {
+      props.setProperty("filterAgencyId", value);
+    }
+  }
+
+  public String getFilterResourceId() {
+    return props.getProperty("filterResourceId");
+  }
+
+  public void setFilterResourceId(String value) {
+    if (value == null) {
+      props.remove("filterResourceId");
+    } else {
+      props.setProperty("filterResourceId", value);
+    }
+  }
+
+  public String getFilterClientId() {
+    return props.getProperty("filterClientId");
+  }
+
+  public void setFilterClientId(String value) {
+    if (value == null) {
+      props.remove("filterClientId");
+    } else {
+      props.setProperty("filterClientId", value);
+    }
+  }
+
+  public String getFilterQuery() {
+    return props.getProperty("filterQuery", "");
+  }
+
+  public void setFilterQuery(String value) {
+    props.setProperty("filterQuery", value == null ? "" : value);
+  }
+
+  public String getDayIso() {
+    return props.getProperty("dayIso");
+  }
+
+  public void setDayIso(String value) {
+    if (value == null) {
+      props.remove("dayIso");
+    } else {
+      props.setProperty("dayIso", value);
+    }
+  }
 }

--- a/client/src/main/java/com/location/client/ui/TopBar.java
+++ b/client/src/main/java/com/location/client/ui/TopBar.java
@@ -1,0 +1,260 @@
+package com.location.client.ui;
+
+import com.location.client.core.Models;
+import com.location.client.core.Preferences;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerDateModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+public class TopBar extends JPanel {
+  private final PlanningPanel planning;
+  private final Preferences preferences;
+  private final JComboBox<Models.Agency> cbAgency = new JComboBox<>();
+  private final JComboBox<Models.Resource> cbResource = new JComboBox<>();
+  private final JComboBox<Models.Client> cbClient = new JComboBox<>();
+  private final JTextField tfQuery = new JTextField();
+  private final JSpinner spDate = new JSpinner(new SpinnerDateModel());
+  private boolean updating = false;
+
+  public TopBar(PlanningPanel planning, Preferences preferences) {
+    this.planning = planning;
+    this.preferences = preferences;
+
+    setLayout(new BorderLayout(8, 8));
+    JPanel left = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 6));
+    JPanel right = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 6));
+
+    JButton prev = new JButton("\u25C0");
+    JButton next = new JButton("\u25B6");
+    JButton today = new JButton("Aujourd'hui");
+    prev.addActionListener(e -> prevDay());
+    next.addActionListener(e -> nextDay());
+    today.addActionListener(e -> setDay(LocalDate.now()));
+
+    spDate.setEditor(new JSpinner.DateEditor(spDate, "yyyy-MM-dd"));
+    spDate.addChangeListener(new ChangeListener() {
+      @Override
+      public void stateChanged(ChangeEvent e) {
+        if (updating) {
+          return;
+        }
+        Object value = spDate.getValue();
+        if (value instanceof Date date) {
+          LocalDate local = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+          setDay(local);
+        }
+      }
+    });
+
+    left.add(prev);
+    left.add(next);
+    left.add(today);
+    left.add(spDate);
+
+    configureRenderer(cbAgency, Models.Agency::name);
+    configureRenderer(cbResource, Models.Resource::name);
+    configureRenderer(cbClient, Models.Client::name);
+
+    cbAgency.addActionListener(
+        e -> {
+          if (updating) {
+            return;
+          }
+          Models.Agency agency = (Models.Agency) cbAgency.getSelectedItem();
+          String id = agency == null ? null : agency.id();
+          planning.setFilterAgency(id);
+          preferences.setFilterAgencyId(id);
+          preferences.save();
+          refreshCombos();
+        });
+    cbResource.addActionListener(
+        e -> {
+          if (updating) {
+            return;
+          }
+          Models.Resource resource = (Models.Resource) cbResource.getSelectedItem();
+          String id = resource == null ? null : resource.id();
+          planning.setFilterResource(id);
+          preferences.setFilterResourceId(id);
+          preferences.save();
+        });
+    cbClient.addActionListener(
+        e -> {
+          if (updating) {
+            return;
+          }
+          Models.Client client = (Models.Client) cbClient.getSelectedItem();
+          String id = client == null ? null : client.id();
+          planning.setFilterClient(id);
+          preferences.setFilterClientId(id);
+          preferences.save();
+        });
+
+    tfQuery.setColumns(16);
+    tfQuery.addActionListener(
+        e -> {
+          if (updating) {
+            return;
+          }
+          planning.setFilterQuery(tfQuery.getText());
+          preferences.setFilterQuery(tfQuery.getText());
+          preferences.save();
+        });
+
+    right.add(new JLabel("Agence:"));
+    right.add(cbAgency);
+    right.add(new JLabel("Ressource:"));
+    right.add(cbResource);
+    right.add(new JLabel("Client:"));
+    right.add(cbClient);
+    right.add(new JLabel("Recherche:"));
+    right.add(tfQuery);
+
+    add(left, BorderLayout.WEST);
+    add(right, BorderLayout.EAST);
+
+    String savedDay = preferences.getDayIso();
+    if (savedDay != null && !savedDay.isBlank()) {
+      setDay(LocalDate.parse(savedDay));
+    } else {
+      setDay(planning.getDay());
+    }
+    String savedQuery = preferences.getFilterQuery();
+    tfQuery.setText(savedQuery);
+    planning.setFilterQuery(savedQuery);
+    preferences.setFilterQuery(savedQuery);
+    preferences.save();
+    refreshCombos();
+    selectById(cbAgency, Models.Agency::id, preferences.getFilterAgencyId());
+    selectById(cbResource, Models.Resource::id, preferences.getFilterResourceId());
+    selectById(cbClient, Models.Client::id, preferences.getFilterClientId());
+    updating = false;
+  }
+
+  public void refreshCombos() {
+    updating = true;
+    try {
+      String agencyId = planning.getFilterAgencyId();
+      String resourceId = planning.getFilterResourceId();
+      String clientId = planning.getFilterClientId();
+
+      List<Models.Agency> agencies = planning.getAgencies();
+      cbAgency.removeAllItems();
+      cbAgency.addItem(new Models.Agency(null, "(toutes agences)"));
+      agencies.forEach(cbAgency::addItem);
+      selectById(cbAgency, Models.Agency::id, agencyId);
+
+      List<Models.Resource> resources = planning.getResources();
+      cbResource.removeAllItems();
+      cbResource.addItem(new Models.Resource(null, "(toutes ressources)", "", null, null));
+      resources.forEach(cbResource::addItem);
+      selectById(cbResource, Models.Resource::id, resourceId);
+
+      List<Models.Client> clients = planning.getClients();
+      cbClient.removeAllItems();
+      cbClient.addItem(new Models.Client(null, "(tous clients)", ""));
+      clients.forEach(cbClient::addItem);
+      selectById(cbClient, Models.Client::id, clientId);
+    } finally {
+      updating = false;
+    }
+  }
+
+  private static <T> void configureRenderer(JComboBox<T> combo, Function<T, String> labelProvider) {
+    combo.setRenderer(
+        new DefaultListCellRenderer() {
+          @Override
+          public Component getListCellRendererComponent(
+              JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            if (value != null) {
+              @SuppressWarnings("unchecked")
+              T typed = (T) value;
+              setText(labelProvider.apply(typed));
+            } else {
+              setText("");
+            }
+            return this;
+          }
+        });
+  }
+
+  private static <T> void selectById(
+      JComboBox<T> comboBox, Function<T, String> idExtractor, String id) {
+    if (comboBox.getItemCount() == 0) {
+      return;
+    }
+    if (id == null || id.isBlank()) {
+      comboBox.setSelectedIndex(0);
+      return;
+    }
+    for (int i = 0; i < comboBox.getItemCount(); i++) {
+      T item = comboBox.getItemAt(i);
+      if (item != null && id.equals(idExtractor.apply(item))) {
+        comboBox.setSelectedIndex(i);
+        return;
+      }
+    }
+    comboBox.setSelectedIndex(0);
+  }
+
+  private void setDay(LocalDate day) {
+    if (day == null) {
+      return;
+    }
+    planning.setDay(day);
+    preferences.setDayIso(day.toString());
+    preferences.save();
+    updating = true;
+    try {
+      spDate.setValue(Date.from(day.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+    } finally {
+      updating = false;
+    }
+  }
+
+  public void prevDay() {
+    setDay(planning.getDay().minusDays(1));
+  }
+
+  public void nextDay() {
+    setDay(planning.getDay().plusDays(1));
+  }
+
+  public java.time.OffsetDateTime getFrom() {
+    return planning.getDay().atTime(0, 0).atOffset(ZoneOffset.UTC);
+  }
+
+  public java.time.OffsetDateTime getTo() {
+    return planning.getDay().plusDays(1).atTime(0, 0).atOffset(ZoneOffset.UTC);
+  }
+
+  public String getResourceId() {
+    return planning.getFilterResourceId();
+  }
+
+  public String getClientId() {
+    return planning.getFilterClientId();
+  }
+
+  public String getQuery() {
+    return planning.getFilterQuery();
+  }
+}

--- a/client/src/test/java/com/location/client/ui/PreferencesTest.java
+++ b/client/src/test/java/com/location/client/ui/PreferencesTest.java
@@ -1,0 +1,38 @@
+package com.location.client.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.location.client.core.Preferences;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PreferencesTest {
+  @Test
+  void store_and_read_filters_ok(@TempDir Path home) {
+    String previousHome = System.getProperty("user.home");
+    System.setProperty("user.home", home.toString());
+    try {
+      Preferences prefs = Preferences.load();
+      prefs.setFilterQuery("test");
+      prefs.setFilterAgencyId("A");
+      prefs.setFilterClientId("C");
+      prefs.setFilterResourceId("R");
+      prefs.setDayIso("2025-01-02");
+      prefs.save();
+
+      Preferences reloaded = Preferences.load();
+      assertEquals("test", reloaded.getFilterQuery());
+      assertEquals("A", reloaded.getFilterAgencyId());
+      assertEquals("C", reloaded.getFilterClientId());
+      assertEquals("R", reloaded.getFilterResourceId());
+      assertEquals("2025-01-02", reloaded.getDayIso());
+    } finally {
+      if (previousHome != null) {
+        System.setProperty("user.home", previousHome);
+      } else {
+        System.clearProperty("user.home");
+      }
+    }
+  }
+}

--- a/server/src/test/java/com/location/server/api/v1/ApiV1CsvTest.java
+++ b/server/src/test/java/com/location/server/api/v1/ApiV1CsvTest.java
@@ -1,0 +1,26 @@
+package com.location.server.api.v1;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ApiV1CsvTest {
+  @Autowired MockMvc mockMvc;
+
+  @Test
+  void csv_ok_with_attachment_header() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/interventions/csv"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Disposition", containsString("attachment")));
+  }
+}


### PR DESCRIPTION
## Summary
- add a CSV export endpoint to the REST API with filtering and a WebMvc regression test
- implement a Swing top bar that persists filters, adds day navigation, and supports REST CSV downloads
- extend client preferences coverage and refresh the Sprint 4 documentation

## Testing
- `mvn -B -ntp verify` *(fails: network unreachable while downloading Maven parents/dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d55a818e7083308e24a212086af758