### PR TITLE
feat: add resource unavailability management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,34 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
-## Sprint 4 — Filtres, Navigation Jour & Export CSV REST (Full)
+## Sprint 5 — Indisponibilités Ressource, Conflits & UI (Full)
 
-### Nouvelles fonctionnalités
-- **Navigation jour** (← / → et sélecteur de date) dans le planning.
-- **Filtres** : Agence, Ressource, Client, Recherche texte (titre).
-- **Export CSV côté serveur** : `GET /api/v1/interventions/csv?from&to&resourceId&clientId&q` (UTF‑8, `text/csv` avec `Content-Disposition`).
-- **Export CSV côté client** (Mock ou REST) depuis menu Fichier ou `Ctrl+E`.
-- **Préférences** : persistance des derniers filtres et de la dernière date (`~/.location/app.properties`).
-- **Accessibilité** : focus clair, raccourcis `Ctrl+←/→` pour naviguer dans les jours.
+### Nouveautés
+- **Indisponibilités** (maintenance, panne, congés chauffeur) par ressource :
+  - Backend : entité `Unavailability` + endpoints **REST** `/api/v1/unavailabilities` (`GET`, `POST`).
+  - **Règles de conflit** : création d'une **intervention** refusée si elle chevauche une indisponibilité de la ressource (**409 Conflict**).
+  - **Règles d'intégrité** : interdiction de créer une indisponibilité qui chevauche une intervention existante (409).
+- **UI Planning** : affichage des indisponibilités en **bandes rouges hachurées** derrière les tuiles, tooltip, et **menu** pour en créer.
+- **Mode Mock** : parité fonctionnelle (liste/création + détection de conflits).
+- **Prefs** : inchangées (les filtres/date continuent d'être persistés).
 
-### Démarrage rapide
+### Endpoints ajoutés
+- `GET  /api/v1/unavailabilities?from&to&resourceId`
+- `POST /api/v1/unavailabilities` (validation + anti-chevauchement avec interventions et autres indispos)
+
+### Migrations DB
+- `V4__unavailability.sql`
+
+### Tests
+- Service : intervention refusée si chevauche **indisponibilité** (409).
+- WebMvc : création d’indisponibilité refusée en cas de chevauchement avec intervention existante (409).
+
+### Utilisation rapide
 ```bash
 mvn -B -ntp verify
 mvn -pl server spring-boot:run -Dspring-boot.run.profiles=dev
-# Client
 mvn -pl client -DskipTests package && java -jar client/target/location-client.jar --datasource=mock
 ```
-
-### Endpoints ajoutés
-- `GET /api/v1/interventions/csv?from&to&resourceId&clientId&q` → CSV
-
-### Tests
-- WebMvc : CSV 200 + header `attachment`.
-- UI : simple test de persistance des préférences.
 
 ## Auth & SSE
 - `POST /auth/login` → `{ "token": "..." }`

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -17,4 +17,9 @@ public interface DataSourceProvider extends AutoCloseable {
       java.time.OffsetDateTime from, java.time.OffsetDateTime to, String resourceId);
 
   Models.Intervention createIntervention(Models.Intervention intervention);
+
+  List<Models.Unavailability> listUnavailabilities(
+      java.time.OffsetDateTime from, java.time.OffsetDateTime to, String resourceId);
+
+  Models.Unavailability createUnavailability(Models.Unavailability unavailability);
 }

--- a/client/src/main/java/com/location/client/core/Models.java
+++ b/client/src/main/java/com/location/client/core/Models.java
@@ -19,4 +19,7 @@ public final class Models {
       String title,
       Instant start,
       Instant end) {}
+
+  public record Unavailability(
+      String id, String resourceId, String reason, Instant start, Instant end) {}
 }

--- a/client/src/test/java/com/location/client/ui/PlanningUnavailabilityTest.java
+++ b/client/src/test/java/com/location/client/ui/PlanningUnavailabilityTest.java
@@ -1,0 +1,17 @@
+package com.location.client.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.location.client.core.MockDataSource;
+import org.junit.jupiter.api.Test;
+
+class PlanningUnavailabilityTest {
+
+  @Test
+  void mockContainsUnavailabilities() {
+    MockDataSource mock = new MockDataSource();
+    PlanningPanel panel = new PlanningPanel(mock);
+    panel.setSize(800, 600);
+    assertFalse(panel.getUnavailabilities().isEmpty());
+  }
+}

--- a/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
+++ b/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
@@ -4,6 +4,7 @@ import com.location.server.domain.Agency;
 import com.location.server.domain.Client;
 import com.location.server.domain.Intervention;
 import com.location.server.domain.Resource;
+import com.location.server.domain.Unavailability;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -56,6 +57,18 @@ public final class ApiV1Dtos {
     }
   }
 
+  public record UnavailabilityDto(
+      String id, String resourceId, OffsetDateTime start, OffsetDateTime end, String reason) {
+    public static UnavailabilityDto of(Unavailability unavailability) {
+      return new UnavailabilityDto(
+          unavailability.getId(),
+          unavailability.getResource().getId(),
+          unavailability.getStart(),
+          unavailability.getEnd(),
+          unavailability.getReason());
+    }
+  }
+
   public record CreateInterventionRequest(
       @NotBlank String agencyId,
       @NotBlank String resourceId,
@@ -63,4 +76,10 @@ public final class ApiV1Dtos {
       @NotBlank @Size(max = 140) String title,
       @NotNull OffsetDateTime start,
       @NotNull OffsetDateTime end) {}
+
+  public record CreateUnavailabilityRequest(
+      @NotBlank String resourceId,
+      @NotNull OffsetDateTime start,
+      @NotNull OffsetDateTime end,
+      @NotBlank @Size(max = 140) String reason) {}
 }

--- a/server/src/main/java/com/location/server/domain/Unavailability.java
+++ b/server/src/main/java/com/location/server/domain/Unavailability.java
@@ -1,0 +1,42 @@
+package com.location.server.domain;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "unavailability",
+    indexes = {
+        @Index(name = "idx_unav_resource_start_end", columnList = "resource_id,start_ts,end_ts")
+    })
+public class Unavailability {
+  @Id
+  private String id;
+
+  @ManyToOne(optional = false) @JoinColumn(name = "resource_id")
+  private Resource resource;
+
+  @Column(name = "start_ts", nullable = false)
+  private OffsetDateTime start;
+
+  @Column(name = "end_ts", nullable = false)
+  private OffsetDateTime end;
+
+  @Column(nullable = false, length = 140)
+  private String reason;
+
+  public Unavailability(){}
+  public Unavailability(String id, Resource resource, OffsetDateTime start, OffsetDateTime end, String reason) {
+    this.id = id; this.resource = resource; this.start = start; this.end = end; this.reason = reason;
+  }
+
+  public String getId() { return id; }
+  public void setId(String id) { this.id = id; }
+  public Resource getResource() { return resource; }
+  public void setResource(Resource resource) { this.resource = resource; }
+  public OffsetDateTime getStart() { return start; }
+  public void setStart(OffsetDateTime start) { this.start = start; }
+  public OffsetDateTime getEnd() { return end; }
+  public void setEnd(OffsetDateTime end) { this.end = end; }
+  public String getReason() { return reason; }
+  public void setReason(String reason) { this.reason = reason; }
+}

--- a/server/src/main/java/com/location/server/repo/UnavailabilityRepository.java
+++ b/server/src/main/java/com/location/server/repo/UnavailabilityRepository.java
@@ -1,0 +1,21 @@
+package com.location.server.repo;
+
+import com.location.server.domain.Unavailability;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UnavailabilityRepository extends JpaRepository<Unavailability, String> {
+  @Query("select u from Unavailability u where (:rid is null or u.resource.id = :rid) " +
+      "and (:from is null or u.end > :from) and (:to is null or u.start < :to)")
+  List<Unavailability> search(@Param("from") OffsetDateTime from,
+                              @Param("to") OffsetDateTime to,
+                              @Param("rid") String resourceId);
+
+  @Query("select count(u)>0 from Unavailability u where u.resource.id=:rid and u.end > :start and u.start < :end")
+  boolean existsOverlap(@Param("rid") String resourceId,
+                        @Param("start") OffsetDateTime start,
+                        @Param("end") OffsetDateTime end);
+}

--- a/server/src/main/java/com/location/server/service/InterventionService.java
+++ b/server/src/main/java/com/location/server/service/InterventionService.java
@@ -8,6 +8,7 @@ import com.location.server.repo.AgencyRepository;
 import com.location.server.repo.ClientRepository;
 import com.location.server.repo.InterventionRepository;
 import com.location.server.repo.ResourceRepository;
+import com.location.server.repo.UnavailabilityRepository;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -19,16 +20,19 @@ public class InterventionService {
   private final AgencyRepository agencyRepository;
   private final ResourceRepository resourceRepository;
   private final ClientRepository clientRepository;
+  private final UnavailabilityRepository unavailabilityRepository;
 
   public InterventionService(
       InterventionRepository interventionRepository,
       AgencyRepository agencyRepository,
       ResourceRepository resourceRepository,
-      ClientRepository clientRepository) {
+      ClientRepository clientRepository,
+      UnavailabilityRepository unavailabilityRepository) {
     this.interventionRepository = interventionRepository;
     this.agencyRepository = agencyRepository;
     this.resourceRepository = resourceRepository;
     this.clientRepository = clientRepository;
+    this.unavailabilityRepository = unavailabilityRepository;
   }
 
   @Transactional
@@ -45,6 +49,9 @@ public class InterventionService {
     if (interventionRepository.existsOverlap(resourceId, start, end)) {
       throw new AssignmentConflictException(
           "Intervention en conflit pour la ressource " + resourceId);
+    }
+    if (unavailabilityRepository.existsOverlap(resourceId, start, end)) {
+      throw new AssignmentConflictException("Ressource indisponible sur le créneau");
     }
     Agency agency = agencyRepository.findById(agencyId).orElseThrow();
     Resource resource = resourceRepository.findById(resourceId).orElseThrow();

--- a/server/src/main/java/com/location/server/service/UnavailabilityService.java
+++ b/server/src/main/java/com/location/server/service/UnavailabilityService.java
@@ -1,0 +1,44 @@
+package com.location.server.service;
+
+import com.location.server.domain.Resource;
+import com.location.server.domain.Unavailability;
+import com.location.server.repo.InterventionRepository;
+import com.location.server.repo.ResourceRepository;
+import com.location.server.repo.UnavailabilityRepository;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UnavailabilityService {
+  private final UnavailabilityRepository unavailabilityRepository;
+  private final ResourceRepository resourceRepository;
+  private final InterventionRepository interventionRepository;
+
+  public UnavailabilityService(
+      UnavailabilityRepository unavailabilityRepository,
+      ResourceRepository resourceRepository,
+      InterventionRepository interventionRepository) {
+    this.unavailabilityRepository = unavailabilityRepository;
+    this.resourceRepository = resourceRepository;
+    this.interventionRepository = interventionRepository;
+  }
+
+  @Transactional
+  public Unavailability create(String resourceId, OffsetDateTime start, OffsetDateTime end, String reason) {
+    if (!start.isBefore(end)) {
+      throw new IllegalArgumentException("start must be before end");
+    }
+    if (unavailabilityRepository.existsOverlap(resourceId, start, end)) {
+      throw new AssignmentConflictException("Chevauchement avec une indisponibilité existante");
+    }
+    if (interventionRepository.existsOverlap(resourceId, start, end)) {
+      throw new AssignmentConflictException("Chevauchement avec une intervention existante");
+    }
+    Resource resource = resourceRepository.findById(resourceId).orElseThrow();
+    Unavailability unavailability =
+        new Unavailability(UUID.randomUUID().toString(), resource, start, end, reason);
+    return unavailabilityRepository.save(unavailability);
+  }
+}

--- a/server/src/main/resources/db/migration/V4__unavailability.sql
+++ b/server/src/main/resources/db/migration/V4__unavailability.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS unavailability (
+  id VARCHAR(36) PRIMARY KEY,
+  resource_id VARCHAR(36) NOT NULL REFERENCES resource(id),
+  start_ts TIMESTAMP WITH TIME ZONE NOT NULL,
+  end_ts   TIMESTAMP WITH TIME ZONE NOT NULL,
+  reason   VARCHAR(140) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_unav_resource_start_end ON unavailability(resource_id, start_ts, end_ts);


### PR DESCRIPTION
## Summary
- introduce the Unavailability JPA entity, repository, service and database migration with REST endpoints and conflict checks
- extend the Java client (mock and REST data sources, planning UI, creation dialog) to list and create unavailabilities and render them in the schedule
- document the sprint 5 scope and add unit tests covering intervention/unavailability conflicts on both server and client

## Testing
- mvn -pl server test *(fails: Maven cannot download parent/boot dependencies because central returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d62fcad9448330a912ac1f6b2f8495