### PR TITLE
Add PDF email stub endpoint and Swing email action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,34 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
-## Sprint 5 — Indisponibilités Ressource, Conflits & UI (Full)
+## Sprint 6 — Emailing PDF (stub), Sélection & Actions (Full)
 
 ### Nouveautés
-- **Indisponibilités** (maintenance, panne, congés chauffeur) par ressource :
-  - Backend : entité `Unavailability` + endpoints **REST** `/api/v1/unavailabilities` (`GET`, `POST`).
-  - **Règles de conflit** : création d'une **intervention** refusée si elle chevauche une indisponibilité de la ressource (**409 Conflict**).
-  - **Règles d'intégrité** : interdiction de créer une indisponibilité qui chevauche une intervention existante (409).
-- **UI Planning** : affichage des indisponibilités en **bandes rouges hachurées** derrière les tuiles, tooltip, et **menu** pour en créer.
-- **Mode Mock** : parité fonctionnelle (liste/création + détection de conflits).
-- **Prefs** : inchangées (les filtres/date continuent d'être persistés).
+- **Emailing de PDF** (stub **dev**) côté backend :
+  - Endpoint `POST /api/v1/documents/{id}/email` body `{to,subject,body}` → `202 Accepted`.
+  - Service `MailGateway` abstrait ; impl **DevMailGateway** loggue l’envoi (sans SMTP).
+  - Réutilise l’export PDF existant (stub) pour simuler la pièce jointe.
+- **Client Swing** :
+  - **Sélection d’intervention** par clic dans le planning (tuile avec halo).
+  - Action **“Envoyer PDF par email…”** (menu *Fichier*) : saisie destinataire/objet/corps, envoi via REST.
+  - En **mode Mock**, l’action affiche un message de simulation.
+- **Prefs** : mémorisation du dernier destinataire (`lastEmailTo`).
+
+### Comment utiliser
+1. Lancer le serveur (profil dev) et le client en REST.
+2. Cliquer une tuile pour la sélectionner.
+3. Menu **Fichier → Envoyer PDF par email…** ; renseigner le mail ; valider.
 
 ### Endpoints ajoutés
-- `GET  /api/v1/unavailabilities?from&to&resourceId`
-- `POST /api/v1/unavailabilities` (validation + anti-chevauchement avec interventions et autres indispos)
-
-### Migrations DB
-- `V4__unavailability.sql`
+- `POST /api/v1/documents/{id}/email`
 
 ### Tests
-- Service : intervention refusée si chevauche **indisponibilité** (409).
-- WebMvc : création d’indisponibilité refusée en cas de chevauchement avec intervention existante (409).
+- WebMvc : email → `202 Accepted` et payload requis.
 
-### Utilisation rapide
 ```bash
 mvn -B -ntp verify
 mvn -pl server spring-boot:run -Dspring-boot.run.profiles=dev
-mvn -pl client -DskipTests package && java -jar client/target/location-client.jar --datasource=mock
+mvn -pl client -DskipTests package && java -jar client/target/location-client.jar --datasource=rest
 ```
 
 ## Auth & SSE

--- a/client/src/main/java/com/location/client/core/Preferences.java
+++ b/client/src/main/java/com/location/client/core/Preferences.java
@@ -72,6 +72,14 @@ public class Preferences {
     props.setProperty("restPass", value);
   }
 
+  public String getLastEmailTo() {
+    return props.getProperty("lastEmailTo", "");
+  }
+
+  public void setLastEmailTo(String value) {
+    props.setProperty("lastEmailTo", value == null ? "" : value);
+  }
+
   public String getFilterAgencyId() {
     return props.getProperty("filterAgencyId");
   }

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -238,6 +238,36 @@ public class RestDataSource implements DataSourceProvider {
     }
   }
 
+  public void emailDocument(String documentId, String to, String subject, String body) {
+    try {
+      ensureLogin();
+      HttpPost post = new HttpPost(baseUrl + "/api/v1/documents/" + encode(documentId) + "/email");
+      ObjectNode payload = om.createObjectNode();
+      if (to == null || to.isBlank()) {
+        throw new IllegalArgumentException("Destinataire requis");
+      }
+      payload.put("to", to);
+      if (subject != null) {
+        payload.put("subject", subject);
+      }
+      if (body != null) {
+        payload.put("body", body);
+      }
+      post.setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
+      http.execute(
+          post,
+          res -> {
+            int code = res.getCode();
+            if (code != 202) {
+              throw new IOException("Email non accepté (" + code + ")");
+            }
+            return null;
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public void downloadPdfStub(String documentId, Path target) throws IOException {
     ensureLogin();
     HttpPost post = new HttpPost(baseUrl + "/api/v1/documents/" + encode(documentId) + "/export/pdf");

--- a/client/src/test/java/com/location/client/ui/SelectionTest.java
+++ b/client/src/test/java/com/location/client/ui/SelectionTest.java
@@ -1,0 +1,15 @@
+package com.location.client.ui;
+
+import com.location.client.core.MockDataSource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelectionTest {
+  @Test
+  void selection_is_null_by_default() {
+    PlanningPanel panel = new PlanningPanel(new MockDataSource());
+    assertNull(panel.getSelected());
+    assertNull(panel.getSelectedInterventionId());
+  }
+}

--- a/server/src/main/java/com/location/server/config/MailConfig.java
+++ b/server/src/main/java/com/location/server/config/MailConfig.java
@@ -1,0 +1,13 @@
+package com.location.server.config;
+
+import com.location.server.service.MailGateway;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MailConfig {
+  @Bean
+  public MailGateway mailGateway() {
+    return new MailGateway.DevMailGateway();
+  }
+}

--- a/server/src/main/java/com/location/server/service/MailGateway.java
+++ b/server/src/main/java/com/location/server/service/MailGateway.java
@@ -1,0 +1,14 @@
+package com.location.server.service;
+
+public interface MailGateway {
+  record Mail(String to, String subject, String body, byte[] pdfAttachment, String filename) {}
+
+  void send(Mail mail);
+
+  class DevMailGateway implements MailGateway {
+    @Override
+    public void send(Mail mail) {
+      System.out.println("[DEV MAIL] to=" + mail.to() + " subject=" + mail.subject() + " attachment=" + mail.filename());
+    }
+  }
+}

--- a/server/src/test/java/com/location/server/api/v1/ApiV1EmailTest.java
+++ b/server/src/test/java/com/location/server/api/v1/ApiV1EmailTest.java
@@ -1,0 +1,35 @@
+package com.location.server.api.v1;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ApiV1EmailTest {
+  @Autowired MockMvc mvc;
+
+  @Test
+  void emailing_returns_accepted() throws Exception {
+    mvc.perform(
+            post("/api/v1/documents/abc/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"to\":\"demo@example.com\",\"subject\":\"Subj\",\"body\":\"Body\"}"))
+        .andExpect(status().isAccepted());
+  }
+
+  @Test
+  void emailing_requires_valid_email() throws Exception {
+    mvc.perform(
+            post("/api/v1/documents/abc/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"to\":\"bad\"}"))
+        .andExpect(status().isBadRequest());
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a MailGateway stub with a `/api/v1/documents/{id}/email` endpoint that reuses the PDF stub and returns 202
- add a Swing selection highlight with a menu/shortcut to send the selected intervention by email while persisting the last recipient
- extend preferences and add backend/frontend tests covering the new behaviours

## Testing
- mvn -B -ntp verify *(fails: cannot resolve parent/boot artifacts due to 403 from Maven Central in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d6365fab5083309a014e2d4648f6e9