### PR TITLE
Add REST edit and delete flow for interventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,40 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Sprint 7 — Édition REST (drag/resize), Suppression & Conflits (Full)
+
+### Nouveautés
+- **Backend REST**
+  - `PUT   /api/v1/interventions/{id}` : mise à jour (titre, agence, ressource, client, start/end).
+  - `DELETE /api/v1/interventions/{id}` : suppression d’une intervention.
+  - **Règles de conflit** conservées : recouvrement entre interventions et **indisponibilités** (`409 Conflict`).
+  - Repo : `existsOverlapExcluding(id, resourceId, start, end)` pour éditer sans se confondre soi‑même.
+  - Tests WebMvc : update OK + update en conflit → 409 ; delete → 204.
+- **Client Swing**
+  - **Drag/resize** maintenant **persistants en REST** (PUT).
+  - **Suppression** d’une intervention sélectionnée (touche `Suppr`/`Delete` ou menu Données).
+  - **Mock** : mêmes opérations en mémoire.
+  - Retours utilisateurs (toast / erreurs) et rechargement du planning.
+
+### Raccourcis
+- `Ctrl+N` nouvelle intervention (Mock déjà pris en charge).
+- **Drag/Resize** sur les tuiles → sauvegarde (REST/Mock).
+- `Suppr` / `Delete` → supprimer l’intervention sélectionnée.
+
+### Endpoints ajoutés
+- `PUT /api/v1/interventions/{id}`
+- `DELETE /api/v1/interventions/{id}`
+
+### Tests
+- `InterventionUpdateWebTest` (update OK + conflit + delete OK).
+
+### Démarrage rapide
+```bash
+mvn -B -ntp verify
+mvn -pl server spring-boot:run -Dspring-boot.run.profiles=dev
+mvn -pl client -DskipTests package && java -jar client/target/location-client.jar --datasource=rest
+```
+
 ## Sprint 6 — Emailing PDF (stub), Sélection & Actions (Full)
 
 ### Nouveautés

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -18,6 +18,10 @@ public interface DataSourceProvider extends AutoCloseable {
 
   Models.Intervention createIntervention(Models.Intervention intervention);
 
+  Models.Intervention updateIntervention(Models.Intervention intervention);
+
+  void deleteIntervention(String id);
+
   List<Models.Unavailability> listUnavailabilities(
       java.time.OffsetDateTime from, java.time.OffsetDateTime to, String resourceId);
 

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -128,6 +128,19 @@ public class MainFrame extends JFrame {
                 emailSelected();
               }
             });
+    getRootPane()
+        .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        .put(KeyStroke.getKeyStroke("DELETE"), "deleteIntervention");
+    getRootPane()
+        .getActionMap()
+        .put(
+            "deleteIntervention",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                deleteSelected();
+              }
+            });
   }
 
   private JMenuBar buildMenuBar() {
@@ -165,9 +178,18 @@ public class MainFrame extends JFrame {
     create.addActionListener(e -> createInterventionDialog());
     JMenuItem newUnav = new JMenuItem("Nouvelle indisponibilité");
     newUnav.addActionListener(e -> createUnavailabilityDialog());
+    JMenuItem deleteIntervention =
+        new JMenuItem(
+            new AbstractAction("Supprimer l'intervention sélectionnée (Suppr)") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                deleteSelected();
+              }
+            });
     data.add(create);
     data.add(reset);
     data.add(newUnav);
+    data.add(deleteIntervention);
 
     JMenu settings = new JMenu("Paramètres");
     JMenuItem switchSrc = new JMenuItem("Changer de source (Mock/REST)");
@@ -296,6 +318,26 @@ public class MainFrame extends JFrame {
         }
       } else {
         JOptionPane.showMessageDialog(this, "(MOCK) Email simulé vers " + to);
+      }
+    }
+  }
+
+  private void deleteSelected() {
+    Models.Intervention sel = planning.getSelected();
+    if (sel == null) {
+      JOptionPane.showMessageDialog(this, "Aucune intervention sélectionnée.");
+      return;
+    }
+    int choice =
+        JOptionPane.showConfirmDialog(
+            this,
+            "Supprimer l'intervention \"" + sel.title() + "\" ?",
+            "Confirmation",
+            JOptionPane.OK_CANCEL_OPTION);
+    if (choice == JOptionPane.OK_OPTION) {
+      boolean done = planning.deleteSelected();
+      if (done) {
+        toast("Intervention supprimée");
       }
     }
   }

--- a/server/src/main/java/com/location/server/api/v1/ApiV1Controller.java
+++ b/server/src/main/java/com/location/server/api/v1/ApiV1Controller.java
@@ -7,6 +7,7 @@ import com.location.server.api.v1.dto.ApiV1Dtos.CreateUnavailabilityRequest;
 import com.location.server.api.v1.dto.ApiV1Dtos.InterventionDto;
 import com.location.server.api.v1.dto.ApiV1Dtos.ResourceDto;
 import com.location.server.api.v1.dto.ApiV1Dtos.UnavailabilityDto;
+import com.location.server.api.v1.dto.ApiV1Dtos.UpdateInterventionRequest;
 import com.location.server.repo.AgencyRepository;
 import com.location.server.repo.ClientRepository;
 import com.location.server.repo.InterventionRepository;
@@ -27,9 +28,11 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -178,6 +181,26 @@ public class ApiV1Controller {
             request.title(),
             request.start(),
             request.end()));
+  }
+
+  @PutMapping("/interventions/{id}")
+  public InterventionDto update(
+      @PathVariable String id, @Valid @RequestBody UpdateInterventionRequest request) {
+    return InterventionDto.of(
+        interventionService.update(
+            id,
+            request.agencyId(),
+            request.resourceId(),
+            request.clientId(),
+            request.title(),
+            request.start(),
+            request.end()));
+  }
+
+  @DeleteMapping("/interventions/{id}")
+  public ResponseEntity<Void> delete(@PathVariable String id) {
+    interventionService.delete(id);
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/unavailabilities")

--- a/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
+++ b/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
@@ -77,6 +77,14 @@ public final class ApiV1Dtos {
       @NotNull OffsetDateTime start,
       @NotNull OffsetDateTime end) {}
 
+  public record UpdateInterventionRequest(
+      @NotBlank String agencyId,
+      @NotBlank String resourceId,
+      @NotBlank String clientId,
+      @NotBlank @Size(max = 140) String title,
+      @NotNull OffsetDateTime start,
+      @NotNull OffsetDateTime end) {}
+
   public record CreateUnavailabilityRequest(
       @NotBlank String resourceId,
       @NotNull OffsetDateTime start,

--- a/server/src/main/java/com/location/server/repo/InterventionRepository.java
+++ b/server/src/main/java/com/location/server/repo/InterventionRepository.java
@@ -22,4 +22,12 @@ public interface InterventionRepository extends JpaRepository<Intervention, Stri
       @Param("rid") String resourceId,
       @Param("start") OffsetDateTime start,
       @Param("end") OffsetDateTime end);
+
+  @Query(
+      "select count(i) > 0 from Intervention i where i.id <> :id and i.resource.id = :rid and i.end > :start and i.start < :end")
+  boolean existsOverlapExcluding(
+      @Param("id") String id,
+      @Param("rid") String resourceId,
+      @Param("start") OffsetDateTime start,
+      @Param("end") OffsetDateTime end);
 }

--- a/server/src/test/java/com/location/server/api/v1/InterventionUpdateWebTest.java
+++ b/server/src/test/java/com/location/server/api/v1/InterventionUpdateWebTest.java
@@ -1,0 +1,105 @@
+package com.location.server.api.v1;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.location.server.domain.Agency;
+import com.location.server.domain.Client;
+import com.location.server.domain.Intervention;
+import com.location.server.domain.Resource;
+import com.location.server.repo.AgencyRepository;
+import com.location.server.repo.ClientRepository;
+import com.location.server.repo.InterventionRepository;
+import com.location.server.repo.ResourceRepository;
+import com.location.server.repo.UnavailabilityRepository;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class InterventionUpdateWebTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired AgencyRepository agencyRepository;
+  @Autowired ClientRepository clientRepository;
+  @Autowired ResourceRepository resourceRepository;
+  @Autowired InterventionRepository interventionRepository;
+  @Autowired UnavailabilityRepository unavailabilityRepository;
+  private String agencyId;
+  private String clientId;
+  private String resourceId;
+  private String interventionId;
+
+  private final OffsetDateTime base = OffsetDateTime.of(2025, 1, 1, 8, 0, 0, 0, ZoneOffset.UTC);
+
+  @BeforeEach
+  void setup() {
+    interventionRepository.deleteAll();
+    unavailabilityRepository.deleteAll();
+    resourceRepository.deleteAll();
+    clientRepository.deleteAll();
+    agencyRepository.deleteAll();
+
+    Agency agency = agencyRepository.save(new Agency("A", "Agence"));
+    Client client = clientRepository.save(new Client("C", "Client", "client@example.test"));
+    Resource resource = resourceRepository.save(new Resource("R", "Ressource", "XX-000-YY", null, agency));
+    Intervention intervention =
+        interventionRepository.save(new Intervention("I1", "Titre", base, base.plusHours(2), agency, resource, client));
+
+    agencyId = agency.getId();
+    clientId = client.getId();
+    resourceId = resource.getId();
+    interventionId = intervention.getId();
+  }
+
+  @Test
+  void update_ok_then_delete_returns_204() throws Exception {
+    String payload =
+        """
+            {"agencyId":"%s","resourceId":"%s","clientId":"%s","title":"MAJ","start":"%s","end":"%s"}
+            """
+            .formatted(agencyId, resourceId, clientId, base.plusHours(1), base.plusHours(3));
+
+    mockMvc
+        .perform(
+            put("/api/v1/interventions/" + interventionId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("MAJ"));
+
+    mockMvc.perform(delete("/api/v1/interventions/" + interventionId)).andExpect(status().isNoContent());
+  }
+
+  @Test
+  void update_conflict_on_overlap_returns_409() throws Exception {
+    Agency agency = agencyRepository.getReferenceById(agencyId);
+    Resource resource = resourceRepository.getReferenceById(resourceId);
+    Client client = clientRepository.getReferenceById(clientId);
+
+    interventionRepository.save(
+        new Intervention("I2", "Autre", base.plusHours(2), base.plusHours(4), agency, resource, client));
+
+    String payload =
+        """
+            {"agencyId":"%s","resourceId":"%s","clientId":"%s","title":"MAJ","start":"%s","end":"%s"}
+            """
+            .formatted(agencyId, resourceId, clientId, base.plusHours(1), base.plusHours(3));
+
+    mockMvc
+        .perform(
+            put("/api/v1/interventions/" + interventionId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+        .andExpect(status().isConflict());
+  }
+}


### PR DESCRIPTION
## Summary
- expose REST endpoints to update and delete interventions while preserving conflict rules
- add client data-source support plus drag/resize persistence and deletion from the planning UI
- cover update and delete behaviour with a dedicated MockMvc integration test

## Testing
- `mvn -pl server test` *(fails: Maven cannot download parent POM – HTTP 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d63bdf91108330ba7cb6183e91dca8