### PR TITLE
Add intervention PDF export and emailing across server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Sprint 10 — Export PDF Intervention + Envoi Email (Full, REST) — Mock sûr (sans écriture disque)
+
+### Nouveautés
+**Backend (Spring Boot)**
+- **PDF Intervention** : `GET /api/v1/interventions/{id}/pdf` → `application/pdf` (OpenPDF).
+- **Email PDF** : `POST /api/v1/interventions/{id}/email` avec `{ "to": "...", "subject": "...", "message": "..." }` → `202 Accepted` et envoi via `MailGateway` (pièce jointe PDF).
+- **Service PDF** : rendu simple (titre, client, ressource, dates).
+- **Tests WebMvc** : vérif `application/pdf` + email `202`.
+
+**Client (Swing)**
+- Menu **Fichier → Exporter Intervention (PDF)** (REST uniquement) : télécharge le PDF et l’ouvre.
+- Menu **Données → Envoyer PDF intervention par email** (REST & Mock) :
+  - En REST : appel direct de l’API d’envoi.
+  - En Mock : **simulation** (succès immédiat, aucune écriture disque conformément aux règles Mock).
+
+**Mode Mock**
+- Pas d’écriture fichier. L’envoi email est simulé côté client.
+
+### Utilisation
+1. Sélectionnez une intervention dans le planning.
+2. **Exporter PDF** pour obtenir le fichier (REST).
+3. **Envoyer PDF par email** pour expédier au destinataire (REST réel, Mock simulé).
+
+### Démarrage
+```bash
+mvn -B -ntp verify
+mvn -pl server spring-boot:run -Dspring-boot.run.profiles=dev
+mvn -pl client -DskipTests package && java -jar client/target/location-client.jar --datasource=rest
+```
+
 ## Sprint 8 — Indisponibilités récurrentes + Tags/Capacité ressources + Export CSV (Full, Mock-ready)
 
 ### Nouveautés

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -32,4 +32,8 @@ public interface DataSourceProvider extends AutoCloseable {
   Models.RecurringUnavailability createRecurringUnavailability(Models.RecurringUnavailability recurring);
 
   java.nio.file.Path downloadResourcesCsv(String tags, java.nio.file.Path target);
+
+  java.nio.file.Path downloadInterventionPdf(String interventionId, java.nio.file.Path target);
+
+  void emailInterventionPdf(String interventionId, String to, String subject, String message);
 }

--- a/client/src/main/java/com/location/client/core/MockDataSource.java
+++ b/client/src/main/java/com/location/client/core/MockDataSource.java
@@ -376,6 +376,17 @@ public class MockDataSource implements DataSourceProvider {
     }
   }
 
+  @Override
+  public java.nio.file.Path downloadInterventionPdf(String interventionId, java.nio.file.Path target) {
+    throw new UnsupportedOperationException(
+        "Export PDF non disponible en mode Mock (aucune écriture disque).");
+  }
+
+  @Override
+  public void emailInterventionPdf(String interventionId, String to, String subject, String message) {
+    // Simulation instantanée : pas d'envoi réel en mode Mock.
+  }
+
   private static boolean overlaps(Instant start, Instant end, Instant from, Instant to) {
     if (from == null || to == null) {
       return true;

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -381,51 +380,73 @@ public class RestDataSource implements DataSourceProvider {
     }
   }
 
-  public void emailDocument(String documentId, String to, String subject, String body) {
+  @Override
+  public Path downloadInterventionPdf(String interventionId, Path target) {
     try {
       ensureLogin();
-      HttpPost post = new HttpPost(baseUrl + "/api/v1/documents/" + encodeSegment(documentId) + "/email");
-      ObjectNode payload = om.createObjectNode();
-      if (to == null || to.isBlank()) {
-        throw new IllegalArgumentException("Destinataire requis");
+      HttpGet get = new HttpGet(baseUrl + "/api/v1/interventions/" + encodeSegment(interventionId) + "/pdf");
+      if (bearer.get() != null) {
+        get.addHeader("Authorization", "Bearer " + bearer.get());
       }
-      payload.put("to", to);
-      if (subject != null) {
-        payload.put("subject", subject);
-      }
-      if (body != null) {
-        payload.put("body", body);
-      }
-      post.setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
-      http.execute(
-          post,
-          res -> {
-            int code = res.getCode();
-            if (code != 202) {
-              throw new IOException("Email non accepté (" + code + ")");
+      return http.execute(
+          get,
+          response -> {
+            int sc = response.getCode();
+            HttpEntity entity = response.getEntity();
+            if (sc >= 200 && sc < 300 && entity != null) {
+              byte[] bytes = EntityUtils.toByteArray(entity);
+              Files.write(target, bytes);
+              return target;
             }
-            return null;
+            String body =
+                entity == null
+                    ? ""
+                    : new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            throw new IOException("HTTP " + sc + " → " + body);
           });
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public void downloadPdfStub(String documentId, Path target) throws IOException {
-    ensureLogin();
-    HttpPost post = new HttpPost(baseUrl + "/api/v1/documents/" + encodeSegment(documentId) + "/export/pdf");
-    http.execute(post, response -> {
-      int sc = response.getCode();
-      HttpEntity entity = response.getEntity();
-      if (sc >= 200 && sc < 300 && entity != null) {
-        try (InputStream in = entity.getContent()) {
-          Files.copy(in, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-        }
-        return null;
+  @Override
+  public void emailInterventionPdf(String interventionId, String to, String subject, String message) {
+    try {
+      ensureLogin();
+      if (to == null || to.isBlank()) {
+        throw new IllegalArgumentException("Destinataire requis");
       }
-      String body = entity == null ? "" : new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8);
-      throw new IOException("HTTP " + sc + " → " + body);
-    });
+      HttpPost post =
+          new HttpPost(baseUrl + "/api/v1/interventions/" + encodeSegment(interventionId) + "/email");
+      if (bearer.get() != null) {
+        post.addHeader("Authorization", "Bearer " + bearer.get());
+      }
+      ObjectNode payload = om.createObjectNode();
+      payload.put("to", to);
+      if (subject != null) {
+        payload.put("subject", subject);
+      }
+      if (message != null) {
+        payload.put("message", message);
+      }
+      post.setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
+      http.execute(
+          post,
+          res -> {
+            int code = res.getCode();
+            HttpEntity entity = res.getEntity();
+            if (code == 202) {
+              return null;
+            }
+            String body =
+                entity == null
+                    ? ""
+                    : new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            throw new IOException("HTTP " + code + " → " + body);
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public Path downloadCsvInterventions(

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -155,22 +155,12 @@ public class MainFrame extends JFrame {
     exportCsvRest.addActionListener(e -> exportCsvRest());
     JMenuItem exportResources = new JMenuItem("Exporter ressources CSV");
     exportResources.addActionListener(e -> exportResourcesCsv());
-    JMenuItem exportPdf = new JMenuItem("Exporter PDF (stub)");
-    exportPdf.addActionListener(e -> exportPdfStub());
-    JMenuItem emailPdf =
-        new JMenuItem(
-            new AbstractAction("Envoyer PDF par email… (Ctrl+M)") {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                emailSelected();
-              }
-            });
-    emailPdf.setAccelerator(KeyStroke.getKeyStroke("control M"));
+    JMenuItem exportInterventionPdf = new JMenuItem("Exporter intervention (PDF)");
+    exportInterventionPdf.addActionListener(e -> exportInterventionPdf());
     file.add(exportCsv);
     file.add(exportCsvRest);
     file.add(exportResources);
-    file.add(exportPdf);
-    file.add(emailPdf);
+    file.add(exportInterventionPdf);
 
     JMenu data = new JMenu("Données");
     JMenuItem reset = new JMenuItem("Réinitialiser la démo (Mock)");
@@ -193,11 +183,21 @@ public class MainFrame extends JFrame {
                 deleteSelected();
               }
             });
+    JMenuItem emailPdf =
+        new JMenuItem(
+            new AbstractAction("Envoyer l'intervention par email… (Ctrl+M)") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                emailSelected();
+              }
+            });
+    emailPdf.setAccelerator(KeyStroke.getKeyStroke("control M"));
     data.add(create);
     data.add(reset);
     data.add(newUnav);
     data.add(newRecurring);
     data.add(deleteIntervention);
+    data.add(emailPdf);
 
     JMenu settings = new JMenu("Paramètres");
     JMenuItem switchSrc = new JMenuItem("Changer de source (Mock/REST)");
@@ -282,14 +282,19 @@ public class MainFrame extends JFrame {
     return value.replace(";", ",");
   }
 
-  private void exportPdfStub() {
-    if (!(dsp instanceof RestDataSource rd)) {
-      toast("PDF (stub) nécessite le mode REST");
+  private void exportInterventionPdf() {
+    Models.Intervention sel = planning.getSelected();
+    if (sel == null) {
+      toast("Sélectionnez une intervention dans le planning.");
+      return;
+    }
+    if (!(dsp instanceof RestDataSource)) {
+      toast("Export PDF disponible uniquement en mode REST.");
       return;
     }
     try {
-      Path out = Files.createTempFile("doc-", ".pdf");
-      rd.downloadPdfStub("demo", out);
+      Path out = Files.createTempFile("intervention-" + sel.id() + "-", ".pdf");
+      dsp.downloadInterventionPdf(sel.id(), out);
       toast("PDF exporté: " + out);
       Desktop.getDesktop().open(out.toFile());
     } catch (Exception ex) {
@@ -309,7 +314,7 @@ public class MainFrame extends JFrame {
     }
     JTextField tfTo = new JTextField(prefs.getLastEmailTo());
     JTextField tfSubject = new JTextField("Intervention " + sel.title());
-    JTextArea taBody = new JTextArea("Bonjour,\nVeuillez trouver le document en pièce jointe.\nCordialement.");
+    JTextArea taBody = new JTextArea("Bonjour,\nVeuillez trouver l'intervention en pièce jointe.\nCordialement.");
     taBody.setLineWrap(true);
     taBody.setWrapStyleWord(true);
     taBody.setRows(6);
@@ -321,22 +326,22 @@ public class MainFrame extends JFrame {
     fields.add(tfSubject);
     panel.add(fields, BorderLayout.NORTH);
     panel.add(new JScrollPane(taBody), BorderLayout.CENTER);
-    int result = JOptionPane.showConfirmDialog(this, panel, "Envoyer PDF par email", JOptionPane.OK_CANCEL_OPTION);
+    int result = JOptionPane.showConfirmDialog(this, panel, "Envoyer l'intervention par email", JOptionPane.OK_CANCEL_OPTION);
     if (result == JOptionPane.OK_OPTION) {
       String to = tfTo.getText().trim();
       String subject = tfSubject.getText();
       String body = taBody.getText();
       prefs.setLastEmailTo(to);
       prefs.save();
-      if (dsp instanceof RestDataSource rd) {
-        try {
-          rd.emailDocument(sel.id(), to, subject, body);
+      try {
+        dsp.emailInterventionPdf(sel.id(), to, subject, body);
+        if (dsp instanceof RestDataSource) {
           toast("Email envoyé (202 Accepted)");
-        } catch (Exception ex) {
-          error(ex.getMessage());
+        } else {
+          toast("Email simulé (mode Mock)");
         }
-      } else {
-        JOptionPane.showMessageDialog(this, "(MOCK) Email simulé vers " + to);
+      } catch (Exception ex) {
+        error(ex.getMessage());
       }
     }
   }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf</artifactId>
+      <version>1.3.32</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/server/src/main/java/com/location/server/service/PdfService.java
+++ b/server/src/main/java/com/location/server/service/PdfService.java
@@ -1,0 +1,113 @@
+package com.location.server.service;
+
+import com.location.server.domain.Client;
+import com.location.server.domain.Intervention;
+import com.location.server.domain.Resource;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import java.io.ByteArrayOutputStream;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PdfService {
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm", Locale.FRENCH);
+
+  public byte[] buildInterventionPdf(Intervention intervention) {
+    try {
+      ByteArrayOutputStream output = new ByteArrayOutputStream();
+      Document document = new Document(PageSize.A4, 36, 36, 36, 36);
+      PdfWriter.getInstance(document, output);
+      document.open();
+
+      Font titleFont = new Font(Font.HELVETICA, 18, Font.BOLD);
+      Font labelFont = new Font(Font.HELVETICA, 11, Font.BOLD);
+      Font valueFont = new Font(Font.HELVETICA, 11);
+      Font footerFont = new Font(Font.HELVETICA, 9, Font.ITALIC);
+
+      Paragraph title =
+          new Paragraph("Intervention — " + safe(intervention.getTitle()), titleFont);
+      title.setSpacingAfter(16f);
+      document.add(title);
+
+      PdfPTable table = new PdfPTable(2);
+      table.setWidthPercentage(100f);
+      table.setSpacingAfter(20f);
+
+      addRow(table, "Agence", intervention.getAgency().getName(), labelFont, valueFont);
+      addRow(table, "Client", buildClient(intervention.getClient()), labelFont, valueFont);
+      addRow(table, "Ressource", buildResource(intervention.getResource()), labelFont, valueFont);
+      addRow(
+          table,
+          "Début",
+          intervention.getStart().format(DATE_TIME_FORMATTER),
+          labelFont,
+          valueFont);
+      addRow(
+          table,
+          "Fin",
+          intervention.getEnd().format(DATE_TIME_FORMATTER),
+          labelFont,
+          valueFont);
+
+      document.add(table);
+
+      Paragraph footer = new Paragraph("Généré par LOCATION", footerFont);
+      footer.setAlignment(Element.ALIGN_RIGHT);
+      document.add(footer);
+
+      document.close();
+      return output.toByteArray();
+    } catch (DocumentException ex) {
+      throw new IllegalStateException("Erreur génération PDF", ex);
+    }
+  }
+
+  private static void addRow(PdfPTable table, String key, String value, Font label, Font font) {
+    PdfPCell left = new PdfPCell(new Phrase(key, label));
+    PdfPCell right = new PdfPCell(new Phrase(safe(value), font));
+    left.setBorderWidth(0.5f);
+    right.setBorderWidth(0.5f);
+    table.addCell(left);
+    table.addCell(right);
+  }
+
+  private static String buildClient(Client client) {
+    if (client == null) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(safe(client.getName()));
+    if (client.getBillingEmail() != null && !client.getBillingEmail().isBlank()) {
+      builder.append(" — ").append(client.getBillingEmail());
+    }
+    return builder.toString();
+  }
+
+  private static String buildResource(Resource resource) {
+    if (resource == null) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(safe(resource.getName()));
+    if (resource.getLicensePlate() != null && !resource.getLicensePlate().isBlank()) {
+      builder.append(" (").append(resource.getLicensePlate()).append(")");
+    }
+    if (resource.getCapacityTons() != null) {
+      builder.append(" - ").append(resource.getCapacityTons()).append(" t");
+    }
+    return builder.toString();
+  }
+
+  private static String safe(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/server/src/test/java/com/location/server/api/v1/PdfAndEmailWebTest.java
+++ b/server/src/test/java/com/location/server/api/v1/PdfAndEmailWebTest.java
@@ -1,0 +1,112 @@
+package com.location.server.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.location.server.domain.Agency;
+import com.location.server.domain.Client;
+import com.location.server.domain.Intervention;
+import com.location.server.domain.Resource;
+import com.location.server.repo.AgencyRepository;
+import com.location.server.repo.ClientRepository;
+import com.location.server.repo.InterventionRepository;
+import com.location.server.repo.ResourceRepository;
+import com.location.server.repo.RecurringUnavailabilityRepository;
+import com.location.server.repo.UnavailabilityRepository;
+import com.location.server.service.MailGateway;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PdfAndEmailWebTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Autowired private AgencyRepository agencyRepository;
+  @Autowired private ClientRepository clientRepository;
+  @Autowired private ResourceRepository resourceRepository;
+  @Autowired private InterventionRepository interventionRepository;
+  @Autowired private UnavailabilityRepository unavailabilityRepository;
+  @Autowired private RecurringUnavailabilityRepository recurringRepository;
+
+  @MockBean private MailGateway mailGateway;
+
+  private String interventionId;
+
+  @BeforeEach
+  void setup() {
+    recurringRepository.deleteAll();
+    unavailabilityRepository.deleteAll();
+    interventionRepository.deleteAll();
+    resourceRepository.deleteAll();
+    clientRepository.deleteAll();
+    agencyRepository.deleteAll();
+
+    Agency agency = agencyRepository.save(new Agency("A", "Agence"));
+    Client client = clientRepository.save(new Client("C", "Client", "client@example.test"));
+    Resource resource = resourceRepository.save(new Resource("R", "Grue", "AB-123-CD", null, agency));
+    Intervention intervention =
+        interventionRepository.save(
+            new Intervention(
+                "I",
+                "Levage",
+                OffsetDateTime.of(2025, 1, 10, 8, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2025, 1, 10, 10, 0, 0, 0, ZoneOffset.UTC),
+                agency,
+                resource,
+                client));
+    interventionId = intervention.getId();
+  }
+
+  @Test
+  void pdf_endpoint_returns_pdf() throws Exception {
+    byte[] content =
+        mvc.perform(get("/api/v1/interventions/" + interventionId + "/pdf"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Content-Type", MediaType.APPLICATION_PDF_VALUE))
+            .andExpect(
+                header()
+                    .string(
+                        "Content-Disposition",
+                        org.hamcrest.Matchers.containsString("intervention-" + interventionId)))
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+
+    assertThat(content).isNotEmpty();
+  }
+
+  @Test
+  void email_endpoint_returns_accepted_and_sends_mail() throws Exception {
+    mvc.perform(
+            post("/api/v1/interventions/" + interventionId + "/email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{" +
+                    "\"to\":\"client@example.test\"," +
+                    "\"subject\":\"Test\"," +
+                    "\"message\":\"Bonjour\"}"))
+        .andExpect(status().isAccepted());
+
+    ArgumentCaptor<MailGateway.Mail> captor = ArgumentCaptor.forClass(MailGateway.Mail.class);
+    verify(mailGateway).send(captor.capture());
+    MailGateway.Mail mail = captor.getValue();
+    assertThat(mail.to()).isEqualTo("client@example.test");
+    assertThat(mail.subject()).isEqualTo("Test");
+    assertThat(mail.pdfAttachment()).isNotNull();
+    assertThat(mail.pdfAttachment().length).isGreaterThan(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add an OpenPDF-based PdfService with new API endpoints to download intervention PDFs and mail them through the MailGateway
- update the Swing client (REST and mock modes) with PDF download/email capabilities and refreshed menus, and document the new sprint
- cover the new endpoints with WebMvc tests

## Testing
- mvn -pl server -am test *(fails: Maven cannot download parent POM in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d64a108dc0833096bfd08e926cc880