### PR TITLE
Add week view toggle and keyboard navigation to planning UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Étape 1 — Planning “pro” (drag, resize, hover, zoom jour/semaine, filtres)
+
+### Ce que ça livre (résumé)
+- **Client Swing**
+  - **Drag & Drop** des interventions (déplacement horaire et changement de ressource au vol).
+  - **Resize** au bord gauche/droit de la tuile pour ajuster la durée.
+  - **Tooltips enrichis** (titre, client, ressource, date/heure, notes).
+  - **Zoom Jour/Semaine** via menu *Affichage* ou raccourcis `Ctrl+1` (jour) / `Ctrl+2` (semaine).
+  - **Filtres rapides** (agence, ressource, client, recherche texte, tags) synchronisés avec la barre supérieure.
+  - **Détection de conflits** : tentative de sauvegarde → appel REST ; conflit (`409`) ⇒ rollback local + message ou bip clavier.
+  - **Accessibilité** : flèches `← → ↑ ↓` pour décaler de 15 min, `Alt+↑/↓` pour changer de ressource.
+
+> Côté **Backend**, la logique de conflit existante (`InterventionService`) est réutilisée ; aucune évolution serveur n'est requise.
+
+### Raccourcis
+- Drag: maintenir la souris sur la tuile, déplacer horizontalement pour changer l'horaire, verticalement pour changer de ressource.
+- Resize: saisir un bord (curseur ↔) et tirer.
+- `Ctrl+1` jour, `Ctrl+2` semaine ; `Ctrl+E` notes ; `Ctrl+M` email PDF ; flèches pour nudges, `Alt+↑/↓` pour changer de ressource.
+
+### Limitations connues
+- La vue s'appuie sur une plage de 12h (07h→19h) et un pas de 15 minutes.
+- La vue semaine affiche 7 colonnes (lun→dim) avec la même granularité.
+
 ## Sprint 12 — CSV Clients & Indispos + Feature Flags API + Aide/À propos (Full, Mock-safe)
 
 Dernier sprint d’endurcissement et de “petits plus” utiles.

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -141,6 +141,34 @@ public class MainFrame extends JFrame {
             });
     getRootPane()
         .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        .put(KeyStroke.getKeyStroke("control 1"), "viewDay");
+    getRootPane()
+        .getActionMap()
+        .put(
+            "viewDay",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                planning.setWeekMode(false);
+                topBar.refreshCombos();
+              }
+            });
+    getRootPane()
+        .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        .put(KeyStroke.getKeyStroke("control 2"), "viewWeek");
+    getRootPane()
+        .getActionMap()
+        .put(
+            "viewWeek",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                planning.setWeekMode(true);
+                topBar.refreshCombos();
+              }
+            });
+    getRootPane()
+        .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         .put(KeyStroke.getKeyStroke("DELETE"), "deleteIntervention");
     getRootPane()
         .getActionMap()
@@ -222,6 +250,24 @@ public class MainFrame extends JFrame {
     data.add(emailPdf);
     data.add(bulkEmail);
 
+    JMenu view = new JMenu("Affichage");
+    JMenuItem dayView = new JMenuItem("Vue Jour (Ctrl+1)");
+    dayView.setAccelerator(KeyStroke.getKeyStroke("control 1"));
+    dayView.addActionListener(
+        e -> {
+          planning.setWeekMode(false);
+          topBar.refreshCombos();
+        });
+    JMenuItem weekView = new JMenuItem("Vue Semaine (Ctrl+2)");
+    weekView.setAccelerator(KeyStroke.getKeyStroke("control 2"));
+    weekView.addActionListener(
+        e -> {
+          planning.setWeekMode(true);
+          topBar.refreshCombos();
+        });
+    view.add(dayView);
+    view.add(weekView);
+
     JMenu settings = new JMenu("Paramètres");
     JMenuItem switchSrc = new JMenuItem("Changer de source (Mock/REST)");
     switchSrc.addActionListener(e -> switchSource());
@@ -240,6 +286,7 @@ public class MainFrame extends JFrame {
 
     bar.add(file);
     bar.add(data);
+    bar.add(view);
     bar.add(settings);
     bar.add(help);
     return bar;

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -13,21 +13,34 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Stroke;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.TextStyle;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 import javax.swing.JPanel;
 import javax.swing.ToolTipManager;
 
@@ -50,6 +63,8 @@ public class PlanningPanel extends JPanel {
   private static final int TIME_W = 80;
   private static final int HOURS = 12;
   private static final int START_HOUR = 7;
+  private static final int SLOT_MINUTES = 15;
+  private static final DayOfWeek WEEK_START = DayOfWeek.MONDAY;
 
   private int colWidth;
   private Tile dragTile;
@@ -57,6 +72,7 @@ public class PlanningPanel extends JPanel {
   private boolean dragResizeLeft;
   private boolean dragResizeRight;
   private Models.Intervention selected;
+  private boolean weekMode;
 
   public PlanningPanel(DataSourceProvider dsp) {
     this.dsp = dsp;
@@ -64,6 +80,75 @@ public class PlanningPanel extends JPanel {
     setOpaque(true);
     reload();
     ToolTipManager.sharedInstance().registerComponent(this);
+    setFocusable(true);
+    setFocusTraversalKeysEnabled(false);
+
+    getInputMap(JComponent.WHEN_FOCUSED)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0), "nudgeLeft");
+    getActionMap()
+        .put(
+            "nudgeLeft",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                nudgeTime(-SLOT_MINUTES);
+              }
+            });
+    getInputMap(JComponent.WHEN_FOCUSED)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0), "nudgeRight");
+    getActionMap()
+        .put(
+            "nudgeRight",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                nudgeTime(SLOT_MINUTES);
+              }
+            });
+    getInputMap(JComponent.WHEN_FOCUSED)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), "nudgeUp");
+    getActionMap()
+        .put(
+            "nudgeUp",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                nudgeTime(-SLOT_MINUTES);
+              }
+            });
+    getInputMap(JComponent.WHEN_FOCUSED)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), "nudgeDown");
+    getActionMap()
+        .put(
+            "nudgeDown",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                nudgeTime(SLOT_MINUTES);
+              }
+            });
+    getInputMap(JComponent.WHEN_FOCUSED)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.ALT_DOWN_MASK), "resourceUp");
+    getActionMap()
+        .put(
+            "resourceUp",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                nudgeResource(-1);
+              }
+            });
+    getInputMap(JComponent.WHEN_FOCUSED)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.ALT_DOWN_MASK), "resourceDown");
+    getActionMap()
+        .put(
+            "resourceDown",
+            new AbstractAction() {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                nudgeResource(1);
+              }
+            });
 
     MouseAdapter adapter = new MouseAdapter() {
       @Override
@@ -88,6 +173,40 @@ public class PlanningPanel extends JPanel {
     };
     addMouseListener(adapter);
     addMouseMotionListener(adapter);
+  }
+
+  public void setWeekMode(boolean week) {
+    if (this.weekMode == week) {
+      return;
+    }
+    this.weekMode = week;
+    reload();
+    repaint();
+  }
+
+  public boolean isWeekMode() {
+    return weekMode;
+  }
+
+  private int getViewDays() {
+    return weekMode ? 7 : 1;
+  }
+
+  private LocalDate getViewStart() {
+    if (weekMode) {
+      return day.with(TemporalAdjusters.previousOrSame(WEEK_START));
+    }
+    return day;
+  }
+
+  public OffsetDateTime getViewFrom() {
+    LocalDate start = getViewStart();
+    return start.atTime(0, 0).atOffset(ZoneOffset.UTC);
+  }
+
+  public OffsetDateTime getViewTo() {
+    LocalDate start = getViewStart();
+    return start.plusDays(getViewDays()).atTime(0, 0).atOffset(ZoneOffset.UTC);
   }
 
   public void reload() {
@@ -121,8 +240,8 @@ public class PlanningPanel extends JPanel {
 
     clients = dsp.listClients();
 
-    var from = day.atTime(0, 0).atOffset(ZoneOffset.UTC);
-    var to = day.plusDays(1).atTime(0, 0).atOffset(ZoneOffset.UTC);
+    OffsetDateTime from = getViewFrom();
+    OffsetDateTime to = getViewTo();
     List<Models.Intervention> data = dsp.listInterventions(from, to, normalize(filterResourceId));
     if (agency != null && !agency.isBlank()) {
       data = data.stream().filter(i -> agency.equals(i.agencyId())).toList();
@@ -275,24 +394,44 @@ public class PlanningPanel extends JPanel {
     g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
     int w = getWidth();
     int h = getHeight();
-    colWidth = (w - TIME_W) / HOURS;
-
-    g2.setColor(new Color(245, 245, 245));
-    g2.fillRect(0, 0, w, HEADER_H);
-    g2.setColor(Color.GRAY);
-    g2.drawLine(0, HEADER_H, w, HEADER_H);
-    g2.setColor(Color.DARK_GRAY);
-    for (int i = 0; i <= HOURS; i++) {
-      int x = TIME_W + i * colWidth;
-      g2.drawLine(x, 0, x, h);
-      if (i < HOURS) {
-        String txt = (START_HOUR + i) + ":00";
-        g2.drawString(txt, x + 4, HEADER_H - 8);
-      }
-    }
+    int viewDays = Math.max(1, getViewDays());
+    int totalCols = Math.max(1, HOURS * viewDays);
+    int availableWidth = Math.max(0, w - TIME_W);
+    colWidth = Math.max(1, availableWidth / totalCols);
+    int dayWidth = colWidth * HOURS;
 
     g2.setColor(new Color(250, 250, 255));
     g2.fillRect(0, 0, TIME_W, h);
+    g2.setColor(new Color(245, 245, 245));
+    g2.fillRect(TIME_W, 0, Math.max(0, w - TIME_W), HEADER_H);
+    g2.setColor(Color.GRAY);
+    g2.drawLine(0, HEADER_H, w, HEADER_H);
+    g2.drawLine(TIME_W, 0, TIME_W, h);
+
+    LocalDate headerStart = getViewStart();
+    for (int d = 0; d < viewDays; d++) {
+      int xDay = TIME_W + d * dayWidth;
+      g2.setColor(new Color(230, 230, 230));
+      g2.drawLine(xDay, 0, xDay, h);
+      g2.setColor(Color.DARK_GRAY);
+      LocalDate current = headerStart.plusDays(d);
+      String label =
+          current.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.getDefault())
+              + " "
+              + current;
+      g2.drawString(label, xDay + 6, 16);
+      g2.setColor(Color.GRAY);
+      for (int i = 0; i <= HOURS; i++) {
+        int x = xDay + i * colWidth;
+        g2.drawLine(x, HEADER_H, x, h);
+        if (d == 0 && i < HOURS) {
+          String txt = (START_HOUR + i) + ":00";
+          g2.drawString(txt, x + 4, HEADER_H - 8);
+        }
+      }
+    }
+    int boundaryX = TIME_W + viewDays * dayWidth;
+    g2.drawLine(boundaryX, 0, boundaryX, h);
 
     g2.setColor(Color.GRAY);
     for (int r = 0; r < resources.size(); r++) {
@@ -373,22 +512,49 @@ public class PlanningPanel extends JPanel {
   }
 
   private int xForInstant(Instant instant) {
+    if (colWidth <= 0) {
+      return TIME_W;
+    }
+    int viewDays = Math.max(1, getViewDays());
+    LocalDate startDate = getViewStart();
+    LocalDate endDate = startDate.plusDays(viewDays);
     ZonedDateTime zoned = instant.atZone(ZoneId.systemDefault());
     LocalDateTime ldt = zoned.toLocalDateTime();
-    if (!ldt.toLocalDate().equals(day)) {
-      ldt = LocalDateTime.of(day, LocalTime.of(START_HOUR, 0));
+    LocalDate date = ldt.toLocalDate();
+    if (date.isBefore(startDate)) {
+      ldt = LocalDateTime.of(startDate, LocalTime.of(START_HOUR, 0));
+    } else if (!date.isBefore(endDate)) {
+      ldt = LocalDateTime.of(endDate.minusDays(1), LocalTime.of(START_HOUR, 0));
     }
+    int dayOffset =
+        (int)
+            Math.max(
+                0,
+                Math.min(viewDays - 1, ChronoUnit.DAYS.between(startDate, ldt.toLocalDate())));
     LocalTime time = ldt.toLocalTime();
     int mins = (time.getHour() - START_HOUR) * 60 + time.getMinute();
     mins = Math.max(0, Math.min(HOURS * 60, mins));
-    return TIME_W + Math.round((mins / 60f) * colWidth);
+    int base = TIME_W + dayOffset * HOURS * colWidth;
+    return base + Math.round((mins / 60f) * colWidth);
   }
 
   private Instant instantForX(int x) {
-    int rel = Math.max(0, Math.min(x - TIME_W, HOURS * colWidth));
-    float hours = rel / (float) colWidth;
-    int totalMins = Math.round(hours * 60f);
-    LocalDateTime ldt = LocalDateTime.of(day, LocalTime.of(START_HOUR, 0)).plusMinutes(totalMins);
+    if (colWidth <= 0) {
+      return getViewFrom().toInstant();
+    }
+    int viewDays = Math.max(1, getViewDays());
+    int totalCols = HOURS * viewDays;
+    int max = totalCols * colWidth;
+    int rel = Math.max(0, Math.min(x - TIME_W, max));
+    float slots = rel / (float) colWidth;
+    int totalMins = Math.round(slots * 60f);
+    int minutesPerDay = HOURS * 60;
+    int dayOffset = Math.min(viewDays - 1, Math.max(0, totalMins / minutesPerDay));
+    int minsInDay = totalMins - dayOffset * minutesPerDay;
+    minsInDay = Math.max(0, Math.min(minutesPerDay, minsInDay));
+    LocalDate targetDay = getViewStart().plusDays(dayOffset);
+    LocalDateTime ldt =
+        LocalDateTime.of(targetDay, LocalTime.of(START_HOUR, 0)).plusMinutes(minsInDay);
     return ldt.atZone(ZoneId.systemDefault()).toInstant();
   }
 
@@ -473,6 +639,76 @@ public class PlanningPanel extends JPanel {
     }
   }
 
+  private void nudgeTime(int minutes) {
+    if (selected == null) {
+      return;
+    }
+    int resourceIndex = indexOfResource(selected.resourceId());
+    if (resourceIndex < 0) {
+      Toolkit.getDefaultToolkit().beep();
+      return;
+    }
+    Instant newStart = selected.start().plus(Duration.ofMinutes(minutes));
+    Instant newEnd = selected.end().plus(Duration.ofMinutes(minutes));
+    if (!newEnd.isAfter(newStart)) {
+      Toolkit.getDefaultToolkit().beep();
+      return;
+    }
+    Models.Resource resource = resources.get(resourceIndex);
+    Models.Intervention updated =
+        new Models.Intervention(
+            selected.id(),
+            resource.agencyId(),
+            resource.id(),
+            selected.clientId(),
+            selected.title(),
+            newStart,
+            newEnd,
+            selected.notes());
+    try {
+      Models.Intervention persisted = dsp.updateIntervention(updated);
+      selected = persisted;
+      reload();
+    } catch (RuntimeException ex) {
+      Toolkit.getDefaultToolkit().beep();
+    }
+  }
+
+  private void nudgeResource(int delta) {
+    if (selected == null || resources.isEmpty()) {
+      Toolkit.getDefaultToolkit().beep();
+      return;
+    }
+    int current = indexOfResource(selected.resourceId());
+    if (current < 0) {
+      Toolkit.getDefaultToolkit().beep();
+      return;
+    }
+    int target = Math.max(0, Math.min(resources.size() - 1, current + delta));
+    if (target == current) {
+      Toolkit.getDefaultToolkit().beep();
+      return;
+    }
+    Models.Resource resource = resources.get(target);
+    Models.Intervention updated =
+        new Models.Intervention(
+            selected.id(),
+            resource.agencyId(),
+            resource.id(),
+            selected.clientId(),
+            selected.title(),
+            selected.start(),
+            selected.end(),
+            selected.notes());
+    try {
+      Models.Intervention persisted = dsp.updateIntervention(updated);
+      selected = persisted;
+      reload();
+    } catch (RuntimeException ex) {
+      Toolkit.getDefaultToolkit().beep();
+    }
+  }
+
   private void updateCursor(Point p) {
     Optional<Tile> ot = findTileAt(p);
     if (ot.isEmpty()) {
@@ -490,6 +726,7 @@ public class PlanningPanel extends JPanel {
   }
 
   private void onPress(Point p) {
+    requestFocusInWindow();
     Optional<Tile> ot = findTileAt(p);
     dragStart = p;
     dragResizeLeft = false;
@@ -532,7 +769,7 @@ public class PlanningPanel extends JPanel {
       tile = tile.shift(dx, targetRow - tile.row);
     }
     int minX = TIME_W;
-    int maxX = TIME_W + HOURS * colWidth;
+    int maxX = TIME_W + HOURS * Math.max(1, getViewDays()) * colWidth;
     int nx1 = Math.max(minX, Math.min(tile.x1, maxX));
     int nx2 = Math.max(minX, Math.min(tile.x2, maxX));
     dragTile = new Tile(tile.i, tile.row, nx1, nx2, tile.alpha);
@@ -587,11 +824,41 @@ public class PlanningPanel extends JPanel {
   @Override
   public String getToolTipText(MouseEvent event) {
     Optional<Tile> ot = findTileAt(event.getPoint());
-    if (ot.isPresent()) {
-      Models.Intervention i = ot.get().i;
-      return "<html><b>" + i.title() + "</b><br/>" + i.start() + " → " + i.end() + "</html>";
+    if (ot.isEmpty()) {
+      return null;
     }
-    return null;
+    Models.Intervention i = ot.get().i;
+    Models.Resource resource = resources.stream().filter(r -> r.id().equals(i.resourceId())).findFirst().orElse(null);
+    Models.Client client = clients.stream().filter(c -> c.id().equals(i.clientId())).findFirst().orElse(null);
+    ZonedDateTime start = i.start().atZone(ZoneId.systemDefault());
+    ZonedDateTime end = i.end().atZone(ZoneId.systemDefault());
+    StringBuilder sb = new StringBuilder("<html><b>")
+        .append(htmlEscape(i.title()))
+        .append("</b><br/>")
+        .append("Client: ")
+        .append(htmlEscape(client != null ? client.name() : i.clientId()))
+        .append("<br/>")
+        .append("Ressource: ")
+        .append(htmlEscape(resource != null ? resource.name() : i.resourceId()))
+        .append("<br/>")
+        .append(start.toLocalDate())
+        .append(' ')
+        .append(start.toLocalTime())
+        .append(" → ")
+        .append(end.toLocalTime());
+    if (i.notes() != null && !i.notes().isBlank()) {
+      sb.append("<br/>Notes: ")
+          .append(htmlEscape(i.notes()).replace("\n", "<br/>"));
+    }
+    sb.append("</html>");
+    return sb.toString();
+  }
+
+  private static String htmlEscape(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
   }
 
   private record Tile(Models.Intervention i, int row, int x1, int x2, float alpha) {

--- a/client/src/main/java/com/location/client/ui/TopBar.java
+++ b/client/src/main/java/com/location/client/ui/TopBar.java
@@ -7,7 +7,6 @@ import java.awt.Component;
 import java.awt.FlowLayout;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
@@ -246,19 +245,21 @@ public class TopBar extends JPanel {
   }
 
   public void prevDay() {
-    setDay(planning.getDay().minusDays(1));
+    long step = planning.isWeekMode() ? 7L : 1L;
+    setDay(planning.getDay().minusDays(step));
   }
 
   public void nextDay() {
-    setDay(planning.getDay().plusDays(1));
+    long step = planning.isWeekMode() ? 7L : 1L;
+    setDay(planning.getDay().plusDays(step));
   }
 
   public java.time.OffsetDateTime getFrom() {
-    return planning.getDay().atTime(0, 0).atOffset(ZoneOffset.UTC);
+    return planning.getViewFrom();
   }
 
   public java.time.OffsetDateTime getTo() {
-    return planning.getDay().plusDays(1).atTime(0, 0).atOffset(ZoneOffset.UTC);
+    return planning.getViewTo();
   }
 
   public String getResourceId() {


### PR DESCRIPTION
## Summary
- document the planning drag/drop, week zoom, and accessibility shortcuts in the README
- add day/week zoom actions to the Swing menu bar plus Ctrl+1 / Ctrl+2 shortcuts
- update the planning panel with week rendering, keyboard nudges, richer tooltips, and conflict-safe updates
- adjust the top bar navigation and export range to align with week mode

## Testing
- mvn -pl client -DskipTests package *(fails: Maven Central access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65ffb0a1883309a610cb61848abf7