### PR TITLE
Implement multi-agency context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Étape 3 — Multi-agences opérationnel (enforcement `X-Agency-Id` + UI de bascule)
+
+### Ce que cette étape apporte
+- **Backend**
+  - Intercepteur global qui **exige** l’en-tête `X-Agency-Id` sur **toutes** les routes `/api/v1/**`.
+  - Contexte requête `AgencyContext` (ThreadLocal) pour accéder à l’agence courante dans les contrôleurs/services.
+  - Requêtes **scopées** par agence (exemple livré : `/api/v1/docs` inclut un filtre `agencyId`).
+  - Réponse **400** si l’en-tête est absent, **403** si l’agence n’existe pas.
+
+- **Client Swing**
+  - **Sélecteur d’agence** (menu **Contexte** → **Agence**).
+  - **Badge** d’état indiquant **Mock/REST** + **Agence**.
+  - Le client **envoie** `X-Agency-Id` à chaque appel REST.
+
+- **Mock**
+  - Contexte agence côté client respecté ; les listes sont **filtrées** sur l’agence courante.
+
+### Utilisation
+1) Choisir l’agence via **Contexte → Agence**.  
+2) En mode REST, toutes les requêtes porteront `X-Agency-Id` et seront filtrées côté serveur.
+
 ## Étape 2 — Cycle Devis → Commande → BL → Facture (Full, Back + Front + Mock)
 
 ### Objectif

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -11,6 +11,10 @@ public interface DataSourceProvider extends AutoCloseable {
 
   List<Models.Client> listClients();
 
+  String getCurrentAgencyId();
+
+  void setCurrentAgencyId(String agencyId);
+
   List<Models.Resource> listResources();
 
   List<Models.Intervention> listInterventions(

--- a/client/src/main/java/com/location/client/core/Preferences.java
+++ b/client/src/main/java/com/location/client/core/Preferences.java
@@ -80,6 +80,18 @@ public class Preferences {
     props.setProperty("lastEmailTo", value == null ? "" : value);
   }
 
+  public String getCurrentAgencyId() {
+    return props.getProperty("currentAgencyId");
+  }
+
+  public void setCurrentAgencyId(String value) {
+    if (value == null || value.isBlank()) {
+      props.remove("currentAgencyId");
+    } else {
+      props.setProperty("currentAgencyId", value);
+    }
+  }
+
   public String getFilterAgencyId() {
     return props.getProperty("filterAgencyId");
   }

--- a/client/src/main/java/com/location/client/ui/DocumentsFrame.java
+++ b/client/src/main/java/com/location/client/ui/DocumentsFrame.java
@@ -204,7 +204,16 @@ public class DocumentsFrame extends JFrame {
     if (title == null || title.isBlank()) {
       return;
     }
-    Models.Doc doc = dataSource.createDoc(type, agencies.get(0).id(), client.id(), title.trim());
+    String agencyId = dataSource.getCurrentAgencyId();
+    if (agencyId == null || agencyId.isBlank()) {
+      JOptionPane.showMessageDialog(
+          this,
+          "Aucune agence active n'est sélectionnée.",
+          "Agence requise",
+          JOptionPane.WARNING_MESSAGE);
+      return;
+    }
+    Models.Doc doc = dataSource.createDoc(type, agencyId, client.id(), title.trim());
     tableModel.add(doc);
     SwingUtilities.invokeLater(() -> {
       int row = table.convertRowIndexToView(tableModel.indexOf(doc));

--- a/server/src/main/java/com/location/server/api/AgencyContext.java
+++ b/server/src/main/java/com/location/server/api/AgencyContext.java
@@ -1,0 +1,27 @@
+package com.location.server.api;
+
+public final class AgencyContext {
+  private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+  private AgencyContext() {}
+
+  public static void set(String agencyId) {
+    CURRENT.set(agencyId);
+  }
+
+  public static String get() {
+    return CURRENT.get();
+  }
+
+  public static String require() {
+    String agencyId = CURRENT.get();
+    if (agencyId == null) {
+      throw new IllegalStateException("No agency context bound to current thread");
+    }
+    return agencyId;
+  }
+
+  public static void clear() {
+    CURRENT.remove();
+  }
+}

--- a/server/src/main/java/com/location/server/api/v1/CommercialDocumentController.java
+++ b/server/src/main/java/com/location/server/api/v1/CommercialDocumentController.java
@@ -1,5 +1,6 @@
 package com.location.server.api.v1;
 
+import com.location.server.api.AgencyContext;
 import com.location.server.domain.CommercialDocument;
 import com.location.server.domain.CommercialDocument.DocType;
 import com.location.server.domain.CommercialDocumentLine;
@@ -57,7 +58,8 @@ public class CommercialDocumentController {
       @RequestParam(required = false)
           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
           OffsetDateTime to) {
-    return documentRepository.search(type, clientId, from, to).stream()
+    String agencyId = AgencyContext.require();
+    return documentRepository.search(agencyId, type, clientId, from, to).stream()
         .map(CommercialDocumentController::toDto)
         .collect(Collectors.toList());
   }

--- a/server/src/main/java/com/location/server/config/AgencyHeaderInterceptor.java
+++ b/server/src/main/java/com/location/server/config/AgencyHeaderInterceptor.java
@@ -1,0 +1,42 @@
+package com.location.server.config;
+
+import com.location.server.api.AgencyContext;
+import com.location.server.repo.AgencyRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AgencyHeaderInterceptor implements HandlerInterceptor {
+  private final AgencyRepository agencyRepository;
+
+  public AgencyHeaderInterceptor(AgencyRepository agencyRepository) {
+    this.agencyRepository = agencyRepository;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    String path = request.getRequestURI();
+    if (path == null || !path.startsWith("/api/v1/")) {
+      return true;
+    }
+    String agencyId = request.getHeader("X-Agency-Id");
+    if (agencyId == null || agencyId.isBlank()) {
+      response.sendError(HttpStatus.BAD_REQUEST.value(), "Header X-Agency-Id is required");
+      return false;
+    }
+    if (!agencyRepository.existsById(agencyId)) {
+      response.sendError(HttpStatus.FORBIDDEN.value(), "Unknown agency");
+      return false;
+    }
+    AgencyContext.set(agencyId);
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    AgencyContext.clear();
+  }
+}

--- a/server/src/main/java/com/location/server/config/WebConfig.java
+++ b/server/src/main/java/com/location/server/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.location.server.config;
+
+import com.location.server.repo.AgencyRepository;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  private final AgencyRepository agencyRepository;
+
+  public WebConfig(AgencyRepository agencyRepository) {
+    this.agencyRepository = agencyRepository;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new AgencyHeaderInterceptor(agencyRepository));
+  }
+}

--- a/server/src/main/java/com/location/server/repo/CommercialDocumentRepository.java
+++ b/server/src/main/java/com/location/server/repo/CommercialDocumentRepository.java
@@ -10,12 +10,14 @@ import org.springframework.data.repository.query.Param;
 public interface CommercialDocumentRepository extends JpaRepository<CommercialDocument, String> {
   @Query(
       "select d from CommercialDocument d "
-          + "where (:type is null or d.type = :type) "
+          + "where d.agency.id = :agencyId "
+          + "and (:type is null or d.type = :type) "
           + "and (:clientId is null or d.client.id = :clientId) "
           + "and (:from is null or d.date >= :from) "
           + "and (:to is null or d.date < :to) "
           + "order by d.date desc")
   List<CommercialDocument> search(
+      @Param("agencyId") String agencyId,
       @Param("type") CommercialDocument.DocType type,
       @Param("clientId") String clientId,
       @Param("from") OffsetDateTime from,


### PR DESCRIPTION
## Summary
- document the multi-agency milestone in the README
- enforce the X-Agency-Id header on backend v1 routes and scope document queries to the active agency
- add agency context APIs to client data sources, propagate the header for REST calls, filter mock data, and surface an agency selector with status badges in the Swing UI

## Testing
- `mvn -pl server test` *(fails: parent POM and Spring Boot BOM cannot be downloaded in the sandbox, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68d668dcae948330b1fc7bf1e1dd502f