### PR TITLE
Add CI workflow and Docker packaging infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+target
+*/target
+.git
+.github
+.idea
+.vscode
+*.iml
+*.log
+logs
+node_modules
+dist
+build
+.DS_Store
+*.patch
+*.zip
+*.tar.gz
+*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,34 @@ on:
     branches: [ main, master ]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - uses: actions/checkout@v4
+      - name: Setup Temurin JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 17
-          cache: maven
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
       - name: Build & Test
-        run: mvn -B -ntp -DskipTests=false verify
-      - name: Package
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp verify
+      - name: Checkstyle
+        run: mvn -B -ntp -DskipTests checkstyle:check
+      - name: PMD
+        run: mvn -B -ntp -DskipTests pmd:check
+
+  docker-server:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build server image
+        run: docker build -t location-server:ci ./server
+      - name: Save image artifact
+        run: |
+          docker save location-server:ci | gzip > server-image.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: server-image
+          path: server-image.tar.gz

--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Étape 4 — Qualité & Packaging (CI + Docker + Compose + Gzip)
+
+### Ce que cette étape livre
+- **CI GitHub Actions** : build Maven, tests, **Checkstyle** & **PMD** (qualité), build image Docker du **server**.
+- **Packaging Docker** :
+  - `server/Dockerfile` multi‑stage (build JAR puis image runtime légère).
+  - `docker-compose.yml` avec **Postgres** (prod), **Mailhog** (dev emails), et **server** attaché au réseau.
+- **Configs Spring** :
+  - `application.yml`: **compression gzip** activée pour les réponses HTTP.
+  - `application-prod.yml`: datasource **Postgres** via variables d’environnement.
+
+### Démarrage rapide (prod-like)
+```bash
+# 1) Construire le JAR
+mvn -B -ntp -DskipTests package
+
+# 2) Construire l'image serveur
+docker build -t location-server:latest ./server
+
+# 3) Lancer l'ensemble (Postgres + Mailhog + Server)
+docker compose up -d
+
+# Server: http://localhost:8080
+# Mailhog UI: http://localhost:8025
+```
+
+### Variables d’environnement (server)
+- `SPRING_PROFILES_ACTIVE=prod`
+- `DB_URL=jdbc:postgresql://db:5432/location`
+- `DB_USER=location`
+- `DB_PASS=location`
+- `JWT_SECRET` (obligatoire en prod)
+
 ## Étape 3 — Multi-agences opérationnel (enforcement `X-Agency-Id` + UI de bascule)
 
 ### Ce que cette étape apporte

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+  <module name="TreeWalker">
+    <module name="UnusedImports"/>
+    <module name="AvoidStarImport"/>
+    <module name="NeedBraces"/>
+    <module name="EmptyBlock"/>
+    <module name="EqualsHashCode"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="IllegalImport"/>
+    <module name="IllegalThrows"/>
+    <module name="InnerAssignment"/>
+    <module name="MissingOverride"/>
+    <module name="OneStatementPerLine"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+    <module name="UnnecessaryParentheses"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+  </module>
+</module>

--- a/config/pmd-ruleset.xml
+++ b/config/pmd-ruleset.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="location-rules" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.github.io/pmd-6.55.0/ruleset_2_0_0.xsd">
+  <description>Règles PMD pour LOCATION</description>
+  <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray"/>
+  <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
+  <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
+  <rule ref="category/java/errorprone.xml/NullAssignment"/>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingGenericException"/>
+  <rule ref="category/java/errorprone.xml/CloseResource"/>
+  <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops"/>
+  <rule ref="category/java/performance.xml/UseStringBufferForStringAppends"/>
+</ruleset>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: location
+      POSTGRES_USER: location
+      POSTGRES_PASSWORD: location
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL","pg_isready -U location"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # UI
+
+  server:
+    image: location-server:latest
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      DB_URL: jdbc:postgresql://db:5432/location
+      DB_USER: location
+      DB_PASS: location
+      JWT_SECRET: changeme-please
+    ports:
+      - "8080:8080"
+
+volumes:
+  dbdata:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,19 @@
+# ==== Build stage ====
+FROM eclipse-temurin:17-jdk AS build
+WORKDIR /app
+
+# Copy the full project to build only the server module
+COPY .. /app
+
+# Build the server module jar
+RUN ./mvnw -q -DskipTests -pl server -am package || mvn -q -DskipTests -pl server -am package
+
+# ==== Runtime stage ====
+FROM eclipse-temurin:17-jre
+ENV JAVA_OPTS="-Xms256m -Xmx512m"
+WORKDIR /opt/app
+
+COPY --from=build /app/server/target/*.jar /opt/app/app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /opt/app/app.jar"]

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -1,16 +1,28 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASS}
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
+    open-in-view: false
   flyway:
     enabled: true
     locations: classpath:db/migration
-server:
-  port: ${SERVER_PORT:8080}
+
 app:
   jwt:
     secret: ${JWT_SECRET}
+
+location:
+  mail:
+    host: mailhog
+    port: 1025
+
+server:
+  port: 8080
+
+logging:
+  level:
+    root: INFO

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,6 +1,22 @@
+server:
+  compression:
+    enabled: true
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,application/pdf
+    min-response-size: 1024
+
 spring:
   application:
     name: location-server
   main:
     banner-mode: "off"
+  jackson:
+    serialization:
+      WRITE_DATES_AS_TIMESTAMPS: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
 logging.level.org.springframework.security: INFO


### PR DESCRIPTION
## Summary
- document the new quality, CI, and packaging capabilities in the README
- add GitHub Actions workflow steps for Maven build, quality gates, and Docker image artifact
- introduce Docker and Compose packaging plus Spring configuration refinements for production profiles
- include Checkstyle and PMD configuration files for static analysis

## Testing
- `mvn -B -ntp -pl server -am test` *(fails: unable to resolve Maven artifacts due to repository access restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66dfd158883309076dbaca536d06d