### PR TITLE
Add generalized CSV exports and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Étape 9 — Exports CSV généralisés (Clients, Ressources, Interventions) + UI d’export
+
+### Ce que cette étape apporte
+**Backend**
+- Nouveaux endpoints **CSV** (UTF‑8, `;`, filtrés par **X-Agency-Id**) :
+  - `GET /api/v1/clients.csv`
+  - `GET /api/v1/resources.csv`
+  - `GET /api/v1/interventions.csv?from=ISO&to=ISO`
+
+**Client Swing**
+- Nouveau menu **Fichier → Exporter…** ouvrant un **ExportDialog** :
+  - Choix du type (**Clients** / **Ressources** / **Interventions**).
+  - Pour **Interventions**, sélection d’un **intervalle de dates**.
+  - Télécharge le CSV en REST et l’**ouvre** automatiquement.
+  - En **Mock**, un message explique que l’export disque est désactivé (conformément aux invariants).
+
+**Mock**
+- Pas d’écriture fichier : levée `UnsupportedOperation` identique à l’étape 5.
+
+### Utilisation
+1) Lancer le backend en `dev` ou la stack Docker.
+2) Côté client en REST, **Fichier → Exporter…**, choisir un type, valider : un `.csv` s’ouvre.
+
 ## Étape 8 — Planning interactif (drag, move, resize, hover) + détection visuelle des conflits
 
 ### Livrables

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -41,6 +41,9 @@ public interface DataSourceProvider extends AutoCloseable {
 
   void emailInterventionPdf(String interventionId, String to, String subject, String message);
 
+  java.nio.file.Path downloadInterventionsCsv(
+      java.time.OffsetDateTime from, java.time.OffsetDateTime to, java.nio.file.Path target);
+
   java.nio.file.Path downloadClientsCsv(java.nio.file.Path target);
 
   java.nio.file.Path downloadUnavailabilitiesCsv(

--- a/client/src/main/java/com/location/client/core/MockDataSource.java
+++ b/client/src/main/java/com/location/client/core/MockDataSource.java
@@ -511,6 +511,13 @@ public class MockDataSource implements DataSourceProvider {
   }
 
   @Override
+  public java.nio.file.Path downloadInterventionsCsv(
+      java.time.OffsetDateTime from, java.time.OffsetDateTime to, java.nio.file.Path target) {
+    throw new UnsupportedOperationException(
+        "Export Interventions CSV indisponible en mode Mock (pas d'écriture fichier).");
+  }
+
+  @Override
   public java.nio.file.Path downloadClientsCsv(java.nio.file.Path target) {
     throw new UnsupportedOperationException(
         "Export Clients CSV indisponible en mode Mock (pas d'écriture fichier).");

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -531,6 +531,37 @@ public class RestDataSource implements DataSourceProvider {
   }
 
   @Override
+  public Path downloadInterventionsCsv(OffsetDateTime from, OffsetDateTime to, Path target) {
+    try {
+      ensureLogin();
+      String url =
+          baseUrl
+              + "/api/v1/interventions.csv?from="
+              + encode(from.toString())
+              + "&to="
+              + encode(to.toString());
+      return execute(
+          () -> new HttpGet(url),
+          res -> {
+            int sc = res.getCode();
+            HttpEntity entity = res.getEntity();
+            if (sc >= 200 && sc < 300 && entity != null) {
+              byte[] bytes = EntityUtils.toByteArray(entity);
+              Files.write(target, bytes);
+              return target;
+            }
+            String body =
+                entity == null
+                    ? ""
+                    : new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            throw new IOException("HTTP " + sc + " → " + body);
+          });
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
   public Path downloadInterventionPdf(String interventionId, Path target) {
     try {
       ensureLogin();

--- a/client/src/main/java/com/location/client/ui/ExportDialog.java
+++ b/client/src/main/java/com/location/client/ui/ExportDialog.java
@@ -1,0 +1,123 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.nio.file.Files;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerDateModel;
+
+public class ExportDialog extends JDialog {
+  private final JComboBox<String> typeCombo =
+      new JComboBox<>(new String[] {"Clients", "Ressources", "Interventions"});
+  private final JSpinner fromSpinner = createDateSpinner(LocalDate.now().minusDays(7));
+  private final JSpinner toSpinner = createDateSpinner(LocalDate.now().plusDays(1));
+  private final DataSourceProvider dataSourceProvider;
+
+  public ExportDialog(MainFrame owner, DataSourceProvider dataSourceProvider) {
+    super(owner, "Exporter (CSV)", true);
+    this.dataSourceProvider = dataSourceProvider;
+    setLayout(new BorderLayout(8, 8));
+
+    JPanel form = new JPanel(new GridLayout(0, 2, 6, 6));
+    form.add(new JLabel("Type :"));
+    form.add(typeCombo);
+    form.add(new JLabel("Depuis :"));
+    form.add(fromSpinner);
+    form.add(new JLabel("Jusqu'à :"));
+    form.add(toSpinner);
+    add(form, BorderLayout.CENTER);
+
+    typeCombo.addActionListener(e -> toggleDates());
+    toggleDates();
+
+    JPanel actions = new JPanel();
+    actions.add(new JButton(new AbstractAction("Exporter") {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        performExport();
+      }
+    }));
+    actions.add(new JButton(new AbstractAction("Fermer") {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        dispose();
+      }
+    }));
+    add(actions, BorderLayout.SOUTH);
+
+    setPreferredSize(new Dimension(420, 180));
+    pack();
+    setLocationRelativeTo(owner);
+  }
+
+  private void toggleDates() {
+    boolean interventionsSelected = "Interventions".equals(typeCombo.getSelectedItem());
+    fromSpinner.setEnabled(interventionsSelected);
+    toSpinner.setEnabled(interventionsSelected);
+  }
+
+  private static JSpinner createDateSpinner(LocalDate date) {
+    SpinnerDateModel model = new SpinnerDateModel();
+    JSpinner spinner = new JSpinner(model);
+    spinner.setEditor(new JSpinner.DateEditor(spinner, "yyyy-MM-dd"));
+    java.util.Calendar calendar = java.util.Calendar.getInstance();
+    calendar.set(date.getYear(), date.getMonthValue() - 1, date.getDayOfMonth(), 0, 0, 0);
+    calendar.set(java.util.Calendar.MILLISECOND, 0);
+    model.setValue(calendar.getTime());
+    return spinner;
+  }
+
+  private LocalDate spinnerValue(JSpinner spinner) {
+    java.util.Date value = (java.util.Date) spinner.getValue();
+    return value.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+  }
+
+  private void performExport() {
+    try {
+      String selection = (String) typeCombo.getSelectedItem();
+      java.nio.file.Path tempFile = Files.createTempFile("location-export-", ".csv");
+      tempFile.toFile().deleteOnExit();
+      if ("Clients".equals(selection)) {
+        tempFile = dataSourceProvider.downloadClientsCsv(tempFile);
+      } else if ("Ressources".equals(selection)) {
+        tempFile = dataSourceProvider.downloadResourcesCsv(null, tempFile);
+      } else {
+        var from =
+            spinnerValue(fromSpinner)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toOffsetDateTime();
+        var to =
+            spinnerValue(toSpinner)
+                .plusDays(1)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toOffsetDateTime();
+        tempFile = dataSourceProvider.downloadInterventionsCsv(from, to, tempFile);
+      }
+      java.awt.Desktop.getDesktop().open(tempFile.toFile());
+    } catch (UnsupportedOperationException ex) {
+      JOptionPane.showMessageDialog(
+          this,
+          "Export CSV indisponible en mode Mock.",
+          "Information",
+          JOptionPane.INFORMATION_MESSAGE);
+    } catch (Exception ex) {
+      JOptionPane.showMessageDialog(
+          this,
+          "Échec export : " + ex.getMessage(),
+          "Erreur",
+          JOptionPane.ERROR_MESSAGE);
+    }
+  }
+}

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -206,6 +206,14 @@ public class MainFrame extends JFrame {
     exportCsv.addActionListener(e -> exportCsv());
     JMenuItem exportCsvRest = new JMenuItem("Exporter CSV (serveur REST)");
     exportCsvRest.addActionListener(e -> exportCsvRest());
+    JMenuItem exportGeneral =
+        new JMenuItem(
+            new AbstractAction("Exporter…") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                new ExportDialog(MainFrame.this, dsp).setVisible(true);
+              }
+            });
     JMenuItem exportResources = new JMenuItem("Exporter ressources CSV");
     exportResources.addActionListener(e -> exportResourcesCsv());
     JMenuItem exportInterventionPdf = new JMenuItem("Exporter intervention (PDF)");
@@ -216,6 +224,7 @@ public class MainFrame extends JFrame {
     exportUnav.addActionListener(e -> exportUnavailabilitiesCsv());
     file.add(exportCsv);
     file.add(exportCsvRest);
+    file.add(exportGeneral);
     file.add(exportResources);
     file.add(exportInterventionPdf);
     file.add(exportClients);

--- a/server/src/main/java/com/location/server/api/v1/ExportController.java
+++ b/server/src/main/java/com/location/server/api/v1/ExportController.java
@@ -1,0 +1,131 @@
+package com.location.server.api.v1;
+
+import com.location.server.api.AgencyContext;
+import com.location.server.repo.ClientRepository;
+import com.location.server.repo.InterventionRepository;
+import com.location.server.repo.ResourceRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ExportController {
+  private final ClientRepository clientRepository;
+  private final ResourceRepository resourceRepository;
+  private final InterventionRepository interventionRepository;
+
+  public ExportController(
+      ClientRepository clientRepository,
+      ResourceRepository resourceRepository,
+      InterventionRepository interventionRepository) {
+    this.clientRepository = clientRepository;
+    this.resourceRepository = resourceRepository;
+    this.interventionRepository = interventionRepository;
+  }
+
+  @GetMapping(value = "/clients.csv", produces = "text/csv; charset=UTF-8")
+  public ResponseEntity<byte[]> exportClientsCsv() {
+    AgencyContext.require();
+    StringBuilder csv = new StringBuilder("id;name;billingEmail\n");
+    clientRepository
+        .findAll()
+        .forEach(
+            client ->
+                csv.append(client.getId())
+                    .append(';')
+                    .append(sanitize(client.getName()))
+                    .append(';')
+                    .append(
+                        client.getBillingEmail() == null
+                            ? ""
+                            : sanitize(client.getBillingEmail()))
+                    .append('\n'));
+    return csvResponse("clients.csv", csv);
+  }
+
+  @GetMapping(value = "/resources.csv", produces = "text/csv; charset=UTF-8")
+  public ResponseEntity<byte[]> exportResourcesCsv() {
+    String agencyId = AgencyContext.require();
+    StringBuilder csv =
+        new StringBuilder("id;name;licensePlate;capacityTons;tags;agencyId\n");
+    resourceRepository
+        .findAll()
+        .stream()
+        .filter(resource -> resource.getAgency() != null)
+        .filter(resource -> agencyId.equals(resource.getAgency().getId()))
+        .forEach(
+            resource ->
+                csv.append(resource.getId())
+                    .append(';')
+                    .append(sanitize(resource.getName()))
+                    .append(';')
+                    .append(sanitize(resource.getLicensePlate()))
+                    .append(';')
+                    .append(resource.getCapacityTons() == null ? "" : resource.getCapacityTons())
+                    .append(';')
+                    .append(resource.getTags() == null ? "" : sanitize(resource.getTags()))
+                    .append(';')
+                    .append(resource.getAgency().getId())
+                    .append('\n'));
+    return csvResponse("resources.csv", csv);
+  }
+
+  @GetMapping(value = "/interventions.csv", produces = "text/csv; charset=UTF-8")
+  public ResponseEntity<byte[]> exportInterventionsCsv(
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to) {
+    String agencyId = AgencyContext.require();
+    if (from.isAfter(to)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "from must be before to");
+    }
+    StringBuilder csv =
+        new StringBuilder("id;title;clientId;resourceId;driverId;start;end\n");
+    interventionRepository
+        .search(from, to, null)
+        .stream()
+        .filter(intervention -> intervention.getAgency() != null)
+        .filter(intervention -> agencyId.equals(intervention.getAgency().getId()))
+        .forEach(
+            intervention ->
+                csv.append(intervention.getId())
+                    .append(';')
+                    .append(sanitize(intervention.getTitle()))
+                    .append(';')
+                    .append(intervention.getClient().getId())
+                    .append(';')
+                    .append(intervention.getResource().getId())
+                    .append(';')
+                    .append(intervention.getDriver() == null ? "" : intervention.getDriver().getId())
+                    .append(';')
+                    .append(intervention.getStart())
+                    .append(';')
+                    .append(intervention.getEnd())
+                    .append('\n'));
+    return csvResponse("interventions.csv", csv);
+  }
+
+  private static ResponseEntity<byte[]> csvResponse(String filename, StringBuilder content) {
+    byte[] bytes = content.toString().getBytes(StandardCharsets.UTF_8);
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+        .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+        .body(bytes);
+  }
+
+  private static String sanitize(String value) {
+    if (value == null) {
+      return "";
+    }
+    return value.replace(';', ',');
+  }
+}


### PR DESCRIPTION
## Summary
- document the new CSV export step in the README
- expose CSV exports for clients, resources, and interventions on the backend with agency scoping
- add a Swing export dialog with REST-backed downloads and mock guardrails

## Testing
- mvn -pl server test *(fails: cannot reach Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d6810943f08330ac685d0cb12666c2