### PR TITLE
Add SSE ping and resilient client status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## Étape 12 — Stabilisation finale : **SSE ping**, **résilience REST**, **accessibilité & raccourcis**, **indicateur d’état**
+
+### Livré (Back/Front/Mock)
+**Backend**
+- **SSE** `/api/system/ping` : émet un `ping` **toutes ~15s** (profil dev/prod).  
+  Permet au client d’afficher l’état de connexion au backend.
+
+**Client Swing**
+- **Indicateur d’état** (barre de status) : `🟢 REST connecté`, `🟡 tentative…`, `🔴 hors‑ligne` ou `🟣 Mock`.
+- **Abonnement SSE** : thread léger qui consomme `/api/system/ping`. Reconnexion automatique en cas de coupure.
+- **Résilience REST** : retrys exponentiels pour les appels (réseau) *hors* 4xx (limité à 3 essais).
+- **Accessibilité** : mnémotechniques & raccourcis
+  - `Alt+F` Fichier, `Alt+D` Données, `Alt+P` Paramètres, `Alt+A` Aide.
+  - `Ctrl+N` nouvelle intervention (via double‑clic ou menu), `Suppr` supprimer sélection (documents/indispos), `Ctrl+E` Exporter…
+
+**Mock**
+- Inchangé (SSE non utilisé), l’état affiche `🟣 Mock`.
+
+### Test rapide
+1. Lancez le serveur : `mvn -pl server spring-boot:run -Dspring-boot.run.profiles=dev`
+2. Lancez le client en REST : `java -jar client/target/location-client.jar --datasource=rest`  
+   Le badge doit passer à **🟢 REST connecté** et rebondir toutes ~15s.
+3. Coupez le serveur : le client affiche **🔴 hors‑ligne**, puis **🟡 tentative…** en boucle, et se reconnecte.
+
 ## Étape 11 — Modèles documents versionnés (HTML) + Email groupé (full Back/Front/Mock)
 
 ### Nouveautés

--- a/server/src/main/java/com/location/server/api/SystemController.java
+++ b/server/src/main/java/com/location/server/api/SystemController.java
@@ -3,7 +3,10 @@ package com.location.server.api;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,24 +17,50 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/system")
 public class SystemController {
 
+  private static final ScheduledExecutorService SCHEDULER =
+      Executors.newSingleThreadScheduledExecutor(
+          r -> {
+            Thread t = new Thread(r, "system-ping");
+            t.setDaemon(true);
+            return t;
+          });
+
   @GetMapping(value = "/ping", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public SseEmitter ping() {
-    var emitter = new SseEmitter(0L); // no timeout
-    var exec = Executors.newSingleThreadScheduledExecutor();
-    exec.scheduleAtFixedRate(
+    var emitter = new SseEmitter(0L);
+    AtomicReference<ScheduledFuture<?>> futureRef = new AtomicReference<>();
+    Runnable cleanup =
         () -> {
-          try {
-            var data = "ping:" + Instant.now();
-            emitter.send(SseEmitter.event().name("ping").data(data));
-          } catch (IOException e) {
-            emitter.completeWithError(e);
+          ScheduledFuture<?> future = futureRef.getAndSet(null);
+          if (future != null) {
+            future.cancel(true);
           }
-        },
-        0,
-        15,
-        TimeUnit.SECONDS);
-    emitter.onCompletion(exec::shutdown);
-    emitter.onTimeout(exec::shutdown);
+        };
+    ScheduledFuture<?> future =
+        SCHEDULER.scheduleAtFixedRate(
+            () -> {
+              try {
+                emitter.send(
+                    SseEmitter.event().name("ping").data(Instant.now().toString(), MediaType.TEXT_PLAIN));
+              } catch (IllegalStateException e) {
+                cleanup.run();
+                emitter.complete();
+              } catch (IOException e) {
+                cleanup.run();
+                emitter.completeWithError(e);
+              }
+            },
+            0,
+            15,
+            TimeUnit.SECONDS);
+    futureRef.set(future);
+    emitter.onCompletion(cleanup);
+    emitter.onTimeout(
+        () -> {
+          cleanup.run();
+          emitter.complete();
+        });
+    emitter.onError(e -> cleanup.run());
     return emitter;
   }
 }


### PR DESCRIPTION
## Summary
- expose a /api/system/ping SSE endpoint with a shared scheduler so clients can monitor backend connectivity
- harden the REST data source with an SSE listener thread, exponential backoff retries, and explicit HTTP error handling
- surface connection status and refreshed shortcuts in the Swing UI and document the new step in the README

## Testing
- `mvn -pl server -q -DskipTests compile` *(fails: requires artifacts from Maven Central which return 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d688568c14833094c970d7889f5df2