### PR TITLE
Add planning shortcuts and action bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
+## UX++ Tranche E+F — Édition inline + Raccourcis & actions rapides
+
+### Ce que livre ce patch (exécutable)
+**E — Éditeurs inline & validations**
+- **Double‑clic** sur une tuile du planning → **Édition rapide** (titre, heures, ressource) avec **validation immédiate** (fin > début).
+  (Si déjà livré par la tranche précédente, ici on consolide et câblons les actions globales.)
+
+**F — Raccourcis & actions rapides**
+- **Cheat‑sheet** clavier (F1) listant tous les raccourcis.
+- Raccourcis : `Ctrl+N` (nouvelle intervention), `Ctrl+D` (dupliquer), `Suppr` (supprimer), `Alt+←/→` (jour ±1).
+- **Barre d’actions contextuelle** qui apparaît quand une sélection multiple existe : **Dupliquer**, **Supprimer**, **±30 min**.
+
+> Tout est côté client ; aucune API supplémentaire n’est requise. Les suppressions utilisent le provider REST/Mock existant.
+
 ## UX++ Tranche D+E — Aide au placement (suggestions + heatmap) & Édition inline
 
 ### Ce que livre ce patch (exécutable)

--- a/client/src/main/java/com/location/client/ui/CheatSheetDialog.java
+++ b/client/src/main/java/com/location/client/ui/CheatSheetDialog.java
@@ -1,0 +1,35 @@
+package com.location.client.ui;
+
+import java.awt.Dimension;
+import java.awt.Window;
+import javax.swing.BorderFactory;
+import javax.swing.JDialog;
+import javax.swing.JTextArea;
+
+public class CheatSheetDialog extends JDialog {
+  public CheatSheetDialog(Window owner) {
+    super(owner, "Raccourcis clavier", ModalityType.MODELESS);
+    JTextArea shortcuts =
+        new JTextArea(
+            """
+RACCOURCIS — PLANNING
+
+Ctrl+N     : Nouvelle intervention (08:00–10:00)
+Ctrl+D     : Dupliquer la sélection (+1h)
+Suppr      : Supprimer la sélection
+Alt+←/→    : Jour précédent / suivant
+Ctrl+K     : Palette de commandes
+Ctrl+F     : Recherche globale
+Ctrl+Alt+L : Thème clair
+Ctrl+Alt+D : Thème sombre
+Double‑clic: Édition rapide (titre, heures, ressource)
+""");
+    shortcuts.setEditable(false);
+    shortcuts.setOpaque(false);
+    shortcuts.setBorder(BorderFactory.createEmptyBorder(8, 12, 8, 12));
+    add(shortcuts);
+    setPreferredSize(new Dimension(440, 260));
+    pack();
+    setLocationRelativeTo(owner);
+  }
+}


### PR DESCRIPTION
## Summary
- document tranche E+F delivery in the README
- add a cheat sheet dialog and map F1 plus new planning shortcuts
- surface a selection action bar with duplicate/shift/delete helpers backed by PlanningPanel updates

## Testing
- `mvn -pl client -DskipTests package` *(fails: repository access forbidden for parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d69754941883308741e5d5b8151aeb