### PR TITLE
feat: add resource editor and unavailability management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,21 @@
 
 Base **Spring Boot (Java 17)** + **Swing (FlatLaf)** prête :
 
-## UX++ Tranche K+L — Exports CSV & Accessibilité + i18n (FR/EN)
+## UX++ Tranche M+N — Tags & Capacités Ressources + Indisponibilités récurrentes
 
-### Ce que livre ce patch (exécutable, côté **client**)
-**K — Exports CSV**
-- **Export Planning (jour)** en CSV (ressource, début, fin, titre, client).
-- **Export Clients** en CSV.
-- Accès via **Fichier → Export CSV (Planning jour)** et **Export CSV (Clients)**.
+### Ce que livre ce patch (exécutable, Mock complet)
+**M — Ressources enrichies**
+- Éditeur **Ressource** (nom, plaque/type, **capacité**, **tags**).
+- **Recherche** globale qui s’appuie sur les tags (déjà exploités par la recherche globale).
+- Export CSV existant enrichi automatiquement ; ici on ajoute l’édition et la persistance Mock.
 
-**L — Accessibilité & Internationalisation**
-- **Taille de police ajustable** : `Paramètres → Police +`, `Police −`, `Police par défaut` (persistée).
-- **Contraste élevé** (clair/sombre compatible) : `Paramètres → Contraste élevé` (persisté).
-- **Bascule de langue** **Français/English** (persistée). Les libellés nouveaux utilisent le système i18n.
+**N — Indisponibilités récurrentes (ressources)**
+- Nouveau gestionnaire **Indisponibilités** : ajout/suppression de plages pour une ressource, **récurrence** `Aucune` ou `Hebdo` (jour/heure).
+- Intégration **Planning** :
+  - Rendu des plages indisponibles (bandeaux rouges semi-transparents).
+  - **Blocage côté client** : avant enregistrement/déplacement, contrôle anti‑chevauchement avec les indispos (message clair).
+
+> REST : les méthodes existent mais renvoient une erreur explicite si non implémentées côté backend ; tout fonctionne en **Mock**.
 
 ### Build & run (client)
 ```bash

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -83,4 +83,34 @@ public interface DataSourceProvider extends AutoCloseable {
   Models.DocTemplate saveDocTemplate(String docType, String html);
 
   void emailDocsBatch(java.util.List<String> ids, String to, String subject, String message);
+
+  default Models.Resource saveResource(Models.Resource resource) {
+    throw new UnsupportedOperationException("saveResource non disponible dans " + getLabel());
+  }
+
+  default java.util.List<Models.Unavailability> listUnavailability(String resourceId) {
+    throw new UnsupportedOperationException("listUnavailability non disponible dans " + getLabel());
+  }
+
+  default Models.Unavailability saveUnavailability(Models.Unavailability unavailability) {
+    throw new UnsupportedOperationException("saveUnavailability non disponible dans " + getLabel());
+  }
+
+  default void deleteUnavailability(String id) {
+    throw new UnsupportedOperationException("deleteUnavailability non disponible dans " + getLabel());
+  }
+
+  default java.util.List<Models.RecurringUnavailability> listRecurringUnavailability(String resourceId) {
+    return listRecurringUnavailabilities(resourceId);
+  }
+
+  default Models.RecurringUnavailability saveRecurringUnavailability(
+      Models.RecurringUnavailability recurring) {
+    return createRecurringUnavailability(recurring);
+  }
+
+  default void deleteRecurringUnavailability(String id) {
+    throw new UnsupportedOperationException(
+        "deleteRecurringUnavailability non disponible dans " + getLabel());
+  }
 }

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -1070,6 +1070,37 @@ public class RestDataSource implements DataSourceProvider {
     }
   }
 
+  @Override
+  public Models.Resource saveResource(Models.Resource resource) {
+    throw new RuntimeException("saveResource non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public java.util.List<Models.Unavailability> listUnavailability(String resourceId) {
+    throw new RuntimeException("listUnavailability non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public Models.Unavailability saveUnavailability(Models.Unavailability unavailability) {
+    throw new RuntimeException("saveUnavailability non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public void deleteUnavailability(String id) {
+    throw new RuntimeException("deleteUnavailability non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public Models.RecurringUnavailability saveRecurringUnavailability(
+      Models.RecurringUnavailability recurring) {
+    throw new RuntimeException("saveRecurringUnavailability non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public void deleteRecurringUnavailability(String id) {
+    throw new RuntimeException("deleteRecurringUnavailability non disponible sur ce backend (démo).");
+  }
+
   public Path downloadCsvInterventions(
       OffsetDateTime from,
       OffsetDateTime to,

--- a/client/src/main/java/com/location/client/ui/GlobalSearchDialog.java
+++ b/client/src/main/java/com/location/client/ui/GlobalSearchDialog.java
@@ -109,7 +109,17 @@ public class GlobalSearchDialog extends JDialog {
         all.add(new Row("Client", client.id(), client.name()));
       }
       for (Models.Resource resource : dataSourceProvider.listResources()) {
-        all.add(new Row("Ressource", resource.id(), resource.name()));
+        StringBuilder label = new StringBuilder(resource.name());
+        if (resource.tags() != null && !resource.tags().isBlank()) {
+          label.append(" [").append(resource.tags()).append(']');
+        }
+        if (resource.capacityTons() != null) {
+          label.append(" (").append(resource.capacityTons()).append("t)");
+        }
+        if (resource.licensePlate() != null && !resource.licensePlate().isBlank()) {
+          label.append(" – ").append(resource.licensePlate());
+        }
+        all.add(new Row("Ressource", resource.id(), label.toString()));
       }
       for (Models.Doc doc : dataSourceProvider.listDocs(null, null)) {
         all.add(new Row("Document", doc.id(), doc.title()));

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -470,6 +470,22 @@ public class MainFrame extends JFrame {
     newUnav.addActionListener(e -> createUnavailabilityDialog());
     JMenuItem newRecurring = new JMenuItem("Nouvelle indisponibilité récurrente");
     newRecurring.addActionListener(e -> createRecurringUnavailabilityDialog());
+    JMenuItem manageResources =
+        new JMenuItem(
+            new AbstractAction("Gérer les ressources…") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                new ResourceEditorFrame(dsp).setVisible(true);
+              }
+            });
+    JMenuItem manageUnav =
+        new JMenuItem(
+            new AbstractAction("Gérer les indisponibilités…") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                new UnavailabilityFrame(dsp).setVisible(true);
+              }
+            });
     JMenuItem deleteIntervention =
         new JMenuItem(
             new AbstractAction("Supprimer l'intervention sélectionnée (Suppr)") {
@@ -492,6 +508,8 @@ public class MainFrame extends JFrame {
     data.add(editNotes);
     data.add(newUnav);
     data.add(newRecurring);
+    data.add(manageResources);
+    data.add(manageUnav);
     data.add(deleteIntervention);
     data.add(emailPdf);
     data.add(bulkEmail);

--- a/client/src/main/java/com/location/client/ui/ResourceEditorFrame.java
+++ b/client/src/main/java/com/location/client/ui/ResourceEditorFrame.java
@@ -1,0 +1,146 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import com.location.client.core.Models;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JToolBar;
+import javax.swing.table.DefaultTableModel;
+
+public class ResourceEditorFrame extends JFrame {
+  private final DataSourceProvider dataSourceProvider;
+  private final DefaultTableModel model;
+  private final JTable table;
+  private final Map<String, Models.Resource> originals = new HashMap<>();
+  private final Map<String, String> agencyNames = new HashMap<>();
+
+  public ResourceEditorFrame(DataSourceProvider dsp) {
+    super("Ressources");
+    this.dataSourceProvider = dsp;
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setLayout(new BorderLayout(6, 6));
+
+    model =
+        new DefaultTableModel(
+            new Object[] {"ID", "Nom", "Plaque", "Capacité (t)", "Tags", "Agence"},
+            0) {
+          @Override
+          public boolean isCellEditable(int row, int column) {
+            return column != 0 && column != 5;
+          }
+        };
+    table = new JTable(model);
+    table.setPreferredScrollableViewportSize(new Dimension(840, 360));
+    add(new JScrollPane(table), BorderLayout.CENTER);
+
+    JToolBar toolbar = new JToolBar();
+    toolbar.setFloatable(false);
+    toolbar.add(
+        new JButton(
+            new AbstractAction("Ajouter") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                addRow();
+              }
+            }));
+    toolbar.add(
+        new JButton(
+            new AbstractAction("Enregistrer") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                saveAll();
+              }
+            }));
+    add(toolbar, BorderLayout.NORTH);
+
+    setSize(900, 480);
+    setLocationRelativeTo(null);
+
+    refresh();
+  }
+
+  private void refresh() {
+    originals.clear();
+    agencyNames.clear();
+    model.setRowCount(0);
+    List<Models.Agency> agencies = dataSourceProvider.listAgencies();
+    for (Models.Agency agency : agencies) {
+      agencyNames.put(agency.id(), agency.name());
+    }
+    List<Models.Resource> resources = dataSourceProvider.listResources();
+    for (Models.Resource resource : resources) {
+      originals.put(resource.id(), resource);
+      model.addRow(
+          new Object[] {
+            resource.id(),
+            resource.name(),
+            resource.licensePlate(),
+            resource.capacityTons() == null ? "" : resource.capacityTons(),
+            resource.tags(),
+            agencyNames.getOrDefault(resource.agencyId(), resource.agencyId())
+          });
+    }
+  }
+
+  private void addRow() {
+    String agencyId = dataSourceProvider.getCurrentAgencyId();
+    String agencyLabel = agencyId == null ? "" : agencyNames.getOrDefault(agencyId, agencyId);
+    model.addRow(new Object[] {null, "Nouvelle ressource", "", "", "", agencyLabel});
+  }
+
+  private void saveAll() {
+    boolean updated = false;
+    for (int i = 0; i < model.getRowCount(); i++) {
+      String idRaw = value(model.getValueAt(i, 0));
+      String id = idRaw.isBlank() ? null : idRaw.trim();
+      String name = value(model.getValueAt(i, 1)).trim();
+      String plate = value(model.getValueAt(i, 2)).trim();
+      String capacityRaw = value(model.getValueAt(i, 3));
+      String tags = value(model.getValueAt(i, 4)).trim();
+      Integer capacity = null;
+      if (!capacityRaw.isBlank()) {
+        try {
+          capacity = Integer.parseInt(capacityRaw.trim());
+        } catch (NumberFormatException ex) {
+          Toast.error(this, "Capacité invalide (ligne " + (i + 1) + ")");
+          table.setRowSelectionInterval(i, i);
+          table.editCellAt(i, 3);
+          return;
+        }
+      }
+      Models.Resource previous = id == null ? null : originals.get(id);
+      String agencyId = previous != null ? previous.agencyId() : dataSourceProvider.getCurrentAgencyId();
+      Integer color = previous != null ? previous.colorRgb() : null;
+      try {
+        Models.Resource saved =
+            dataSourceProvider.saveResource(
+                new Models.Resource(id, name, plate, color, agencyId, tags, capacity));
+        model.setValueAt(saved.id(), i, 0);
+        model.setValueAt(agencyNames.getOrDefault(saved.agencyId(), saved.agencyId()), i, 5);
+        originals.put(saved.id(), saved);
+        updated = true;
+      } catch (RuntimeException ex) {
+        Toast.error(this, "Erreur sauvegarde: " + ex.getMessage());
+        table.setRowSelectionInterval(i, i);
+        return;
+      }
+    }
+    if (updated) {
+      Toast.success(this, "Ressources enregistrées");
+      refresh();
+    }
+  }
+
+  private String value(Object obj) {
+    return obj == null ? "" : obj.toString();
+  }
+}

--- a/client/src/main/java/com/location/client/ui/UnavailabilityFrame.java
+++ b/client/src/main/java/com/location/client/ui/UnavailabilityFrame.java
@@ -1,0 +1,260 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import com.location.client.core.Models;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Locale;
+import javax.swing.AbstractAction;
+import javax.swing.DefaultCellEditor;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JToolBar;
+import javax.swing.table.DefaultTableModel;
+
+public class UnavailabilityFrame extends JFrame {
+  private final DataSourceProvider dataSourceProvider;
+  private final JComboBox<Models.Resource> resourceCombo = new JComboBox<>();
+  private final DefaultTableModel model;
+  private final JTable table;
+
+  public UnavailabilityFrame(DataSourceProvider dsp) {
+    super("Indisponibilités ressources");
+    this.dataSourceProvider = dsp;
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setLayout(new BorderLayout(6, 6));
+
+    JPanel top = new JPanel(new FlowLayout(FlowLayout.LEFT));
+    top.add(new JLabel("Ressource:"));
+    for (Models.Resource resource : dataSourceProvider.listResources()) {
+      resourceCombo.addItem(resource);
+    }
+    resourceCombo.addActionListener(e -> refresh());
+    top.add(resourceCombo);
+
+    JToolBar toolbar = new JToolBar();
+    toolbar.setFloatable(false);
+    toolbar.add(
+        new JButton(
+            new AbstractAction("Ajouter") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                addRow();
+              }
+            }));
+    toolbar.add(
+        new JButton(
+            new AbstractAction("Supprimer") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                deleteSelected();
+              }
+            }));
+    toolbar.add(
+        new JButton(
+            new AbstractAction("Enregistrer") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                saveAll();
+              }
+            }));
+    top.add(toolbar);
+    add(top, BorderLayout.NORTH);
+
+    model =
+        new DefaultTableModel(
+            new Object[] {"ID", "Jour", "Début", "Fin", "Récurrence", "Date début", "Date fin", "Raison"},
+            0) {
+          @Override
+          public boolean isCellEditable(int row, int column) {
+            return column != 0;
+          }
+        };
+    table = new JTable(model);
+    table.setPreferredScrollableViewportSize(new Dimension(880, 360));
+    table.getColumnModel().getColumn(1).setCellEditor(new DefaultCellEditor(dayEditor()));
+    table.getColumnModel().getColumn(4).setCellEditor(new DefaultCellEditor(recurrenceEditor()));
+    add(new JScrollPane(table), BorderLayout.CENTER);
+
+    setSize(960, 520);
+    setLocationRelativeTo(null);
+
+    if (resourceCombo.getItemCount() > 0) {
+      resourceCombo.setSelectedIndex(0);
+    }
+  }
+
+  private JComboBox<String> dayEditor() {
+    JComboBox<String> combo = new JComboBox<>();
+    for (DayOfWeek day : DayOfWeek.values()) {
+      combo.addItem(day.name());
+    }
+    return combo;
+  }
+
+  private JComboBox<String> recurrenceEditor() {
+    JComboBox<String> combo = new JComboBox<>();
+    combo.addItem("Aucune");
+    combo.addItem("Hebdo");
+    return combo;
+  }
+
+  private void refresh() {
+    model.setRowCount(0);
+    Models.Resource resource = (Models.Resource) resourceCombo.getSelectedItem();
+    if (resource == null) {
+      return;
+    }
+    try {
+      for (Models.Unavailability unavailability : dataSourceProvider.listUnavailability(resource.id())) {
+        LocalDateTime start = LocalDateTime.ofInstant(unavailability.start(), ZoneId.systemDefault());
+        LocalDateTime end = LocalDateTime.ofInstant(unavailability.end(), ZoneId.systemDefault());
+        model.addRow(
+            new Object[] {
+              unavailability.id(),
+              start.getDayOfWeek().name(),
+              start.toLocalTime().toString(),
+              end.toLocalTime().toString(),
+              "Aucune",
+              start.toLocalDate().toString(),
+              end.toLocalDate().toString(),
+              unavailability.reason()
+            });
+      }
+    } catch (RuntimeException ex) {
+      Toast.error(this, ex.getMessage());
+      return;
+    }
+    try {
+      for (Models.RecurringUnavailability recurring :
+          dataSourceProvider.listRecurringUnavailability(resource.id())) {
+        model.addRow(
+            new Object[] {
+              recurring.id(),
+              recurring.dayOfWeek().name(),
+              recurring.start().toString(),
+              recurring.end().toString(),
+              "Hebdo",
+              "",
+              "",
+              recurring.reason()
+            });
+      }
+    } catch (RuntimeException ex) {
+      Toast.error(this, ex.getMessage());
+    }
+  }
+
+  private void addRow() {
+    model.addRow(
+        new Object[] {
+          null,
+          DayOfWeek.MONDAY.name(),
+          LocalTime.of(8, 0).toString(),
+          LocalTime.of(10, 0).toString(),
+          "Hebdo",
+          LocalDate.now().toString(),
+          LocalDate.now().toString(),
+          "Maintenance"
+        });
+  }
+
+  private void deleteSelected() {
+    int row = table.getSelectedRow();
+    if (row < 0) {
+      return;
+    }
+    String id = stringValue(model.getValueAt(row, 0));
+    String recurrence = stringValue(model.getValueAt(row, 4)).toLowerCase(Locale.ROOT);
+    try {
+      if (!id.isBlank()) {
+        if ("hebdo".equals(recurrence)) {
+          dataSourceProvider.deleteRecurringUnavailability(id);
+        } else {
+          dataSourceProvider.deleteUnavailability(id);
+        }
+      }
+      model.removeRow(row);
+      Toast.success(this, "Indisponibilité supprimée");
+    } catch (RuntimeException ex) {
+      Toast.error(this, ex.getMessage());
+    }
+  }
+
+  private void saveAll() {
+    Models.Resource resource = (Models.Resource) resourceCombo.getSelectedItem();
+    if (resource == null) {
+      return;
+    }
+    boolean updated = false;
+    ZoneId zone = ZoneId.systemDefault();
+    for (int row = 0; row < model.getRowCount(); row++) {
+      String recurrence = stringValue(model.getValueAt(row, 4)).toLowerCase(Locale.ROOT);
+      String reason = stringValue(model.getValueAt(row, 7));
+      try {
+        if ("hebdo".equals(recurrence)) {
+          String idRaw = stringValue(model.getValueAt(row, 0));
+          String dayRaw = stringValue(model.getValueAt(row, 1));
+          DayOfWeek day = DayOfWeek.valueOf(dayRaw.toUpperCase(Locale.ROOT));
+          LocalTime start = LocalTime.parse(stringValue(model.getValueAt(row, 2)));
+          LocalTime end = LocalTime.parse(stringValue(model.getValueAt(row, 3)));
+          Models.RecurringUnavailability saved =
+              dataSourceProvider.saveRecurringUnavailability(
+                  new Models.RecurringUnavailability(
+                      idRaw.isBlank() ? null : idRaw,
+                      resource.id(),
+                      day,
+                      start,
+                      end,
+                      reason));
+          model.setValueAt(saved.id(), row, 0);
+        } else {
+          String idRaw = stringValue(model.getValueAt(row, 0));
+          LocalDate fromDate = LocalDate.parse(stringValue(model.getValueAt(row, 5)));
+          String toDateRaw = stringValue(model.getValueAt(row, 6));
+          LocalDate toDate = toDateRaw.isBlank() ? fromDate : LocalDate.parse(toDateRaw);
+          LocalTime start = LocalTime.parse(stringValue(model.getValueAt(row, 2)));
+          LocalTime end = LocalTime.parse(stringValue(model.getValueAt(row, 3)));
+          Instant startInstant = fromDate.atTime(start).atZone(zone).toInstant();
+          Instant endInstant = toDate.atTime(end).atZone(zone).toInstant();
+          Models.Unavailability saved =
+              dataSourceProvider.saveUnavailability(
+                  new Models.Unavailability(
+                      idRaw.isBlank() ? null : idRaw,
+                      resource.id(),
+                      reason,
+                      startInstant,
+                      endInstant,
+                      false));
+          model.setValueAt(saved.id(), row, 0);
+        }
+        updated = true;
+      } catch (RuntimeException ex) {
+        Toast.error(this, ex.getMessage());
+        table.setRowSelectionInterval(row, row);
+        return;
+      }
+    }
+    if (updated) {
+      Toast.success(this, "Indisponibilités enregistrées");
+      refresh();
+    }
+  }
+
+  private String stringValue(Object value) {
+    return value == null ? "" : value.toString().trim();
+  }
+}


### PR DESCRIPTION
## Summary
- add desktop screens to edit resources and manage one-off or weekly unavailability in the mock data source
- extend data providers with save/delete hooks and wire planning/quick edit flows to block overlaps
- enrich global search metadata and documentation for the new resource capabilities

## Testing
- mvn -pl client -DskipTests package *(fails: unable to resolve parent POM from Maven Central; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a2d169688330aa496ae8c6092e2c