### PR TITLE
Add agency email template support to client data sources

### DIFF
--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -84,6 +84,30 @@ public interface DataSourceProvider extends AutoCloseable {
 
   void emailDocsBatch(java.util.List<String> ids, String to, String subject, String message);
 
+  default Models.EmailTemplate getAgencyEmailTemplate(String agencyId) {
+    return getAgencyEmailTemplate(agencyId, normalizeTemplateKey(null));
+  }
+
+  Models.EmailTemplate getAgencyEmailTemplate(String agencyId, String templateKey);
+
+  default Models.EmailTemplate updateAgencyEmailTemplate(
+      String agencyId, Models.EmailTemplate template) {
+    if (template == null) {
+      throw new IllegalArgumentException("Template e-mail requis");
+    }
+    String key = normalizeTemplateKey(template.key());
+    return updateAgencyEmailTemplate(agencyId, key, template.subject(), template.html());
+  }
+
+  Models.EmailTemplate updateAgencyEmailTemplate(
+      String agencyId, String templateKey, String subject, String html);
+
+  default void emailBulk(java.util.List<String> ids, String toOverride) {
+    throw new UnsupportedOperationException("emailBulk(ids,to) non disponible dans " + getLabel());
+  }
+
+  void emailBulk(java.util.List<String> recipients, String subject, String html);
+
   default Models.Resource saveResource(Models.Resource resource) {
     throw new UnsupportedOperationException("saveResource non disponible dans " + getLabel());
   }
@@ -112,5 +136,9 @@ public interface DataSourceProvider extends AutoCloseable {
   default void deleteRecurringUnavailability(String id) {
     throw new UnsupportedOperationException(
         "deleteRecurringUnavailability non disponible dans " + getLabel());
+  }
+
+  static String normalizeTemplateKey(String templateKey) {
+    return (templateKey == null || templateKey.isBlank()) ? "default" : templateKey;
   }
 }

--- a/client/src/main/java/com/location/client/core/Models.java
+++ b/client/src/main/java/com/location/client/core/Models.java
@@ -52,7 +52,15 @@ public final class Models {
       java.time.LocalTime end,
       String reason) {}
 
-  public record EmailTemplate(String subject, String body) {}
+  public record EmailTemplate(String key, String subject, String html) {
+    public EmailTemplate(String subject, String html) {
+      this(null, subject, html);
+    }
+
+    public String body() {
+      return html;
+    }
+  }
   public record DocTemplate(String html) {}
 
   public record DocLine(String designation, double quantity, double unitPrice, double vatRate) {}

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -112,6 +112,22 @@ public class RestDataSource implements DataSourceProvider {
   }
 
   @Override
+  public Models.EmailTemplate getAgencyEmailTemplate(String agencyId, String templateKey) {
+    throw new RuntimeException("getAgencyEmailTemplate non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public Models.EmailTemplate updateAgencyEmailTemplate(
+      String agencyId, String templateKey, String subject, String html) {
+    throw new RuntimeException("updateAgencyEmailTemplate non disponible sur ce backend (démo).");
+  }
+
+  @Override
+  public void emailBulk(java.util.List<String> recipients, String subject, String html) {
+    throw new RuntimeException("emailBulk non disponible sur ce backend (démo).");
+  }
+
+  @Override
   public List<Models.Agency> listAgencies() {
     try {
       ensureLogin();
@@ -963,9 +979,10 @@ public class RestDataSource implements DataSourceProvider {
       JsonNode node =
           executeForJson(() -> new HttpGet(baseUrl + "/api/v1/templates/" + encodeSegment(docType)));
       if (node.isNull() || node.isMissingNode()) {
-        return new Models.EmailTemplate("", "");
+        return new Models.EmailTemplate(docType, "", "");
       }
-      return new Models.EmailTemplate(node.path("subject").asText(""), node.path("body").asText(""));
+      return new Models.EmailTemplate(
+          docType, node.path("subject").asText(""), node.path("body").asText(""));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -986,7 +1003,8 @@ public class RestDataSource implements DataSourceProvider {
                 put.setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
                 return put;
               });
-      return new Models.EmailTemplate(node.path("subject").asText(""), node.path("body").asText(""));
+      return new Models.EmailTemplate(
+          docType, node.path("subject").asText(""), node.path("body").asText(""));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## Summary
- extend the client-side email template model to carry a key alongside subject and HTML content
- expose new agency-scoped email template methods on the data source API with mock implementations and REST fallbacks
- update mock and REST data sources to persist the new template metadata and default values for document templates

## Testing
- mvn -pl client test *(fails: parent POM and Spring dependencies are unavailable from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da416171408330aa767f60c56fe7fd