### PR TITLE
Add resource type explorer and icons

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -41,6 +41,16 @@
       <version>2.0.13</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-swing</artifactId>
+      <version>1.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-transcoder</artifactId>
+      <version>1.17</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.10.2</version>

--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -21,6 +21,34 @@ public interface DataSourceProvider extends AutoCloseable {
 
   List<Models.Resource> listResources();
 
+  default List<Models.ResourceType> listResourceTypes() {
+    return java.util.List.of();
+  }
+
+  default Models.ResourceType saveResourceType(Models.ResourceType resourceType) {
+    throw new UnsupportedOperationException("saveResourceType non disponible dans " + getLabel());
+  }
+
+  default void deleteResourceType(String id) {
+    throw new UnsupportedOperationException("deleteResourceType non disponible dans " + getLabel());
+  }
+
+  default String getResourceTypeForResource(String resourceId) {
+    return null;
+  }
+
+  default void setResourceTypeForResource(String resourceId, String resourceTypeId) {
+    throw new UnsupportedOperationException("setResourceTypeForResource non disponible dans " + getLabel());
+  }
+
+  default double getResourceDailyRate(String resourceId) {
+    return 0.0;
+  }
+
+  default void setResourceDailyRate(String resourceId, double rate) {
+    throw new UnsupportedOperationException("setResourceDailyRate non disponible dans " + getLabel());
+  }
+
   List<Models.Intervention> listInterventions(
       java.time.OffsetDateTime from, java.time.OffsetDateTime to, String resourceId);
 

--- a/client/src/main/java/com/location/client/core/Models.java
+++ b/client/src/main/java/com/location/client/core/Models.java
@@ -78,4 +78,6 @@ public final class Models {
       double totalVat,
       double totalTtc,
       java.util.List<DocLine> lines) {}
+
+  public record ResourceType(String id, String name, String iconName) {}
 }

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -529,6 +529,18 @@ public class MainFrame extends JFrame {
                 new ResourceEditorFrame(dsp).setVisible(true);
               }
             });
+    JMenuItem exploreResources =
+        new JMenuItem(
+            new AbstractAction("Explorateur de ressources…") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                try {
+                  new ResourceExplorerFrame(dsp).setVisible(true);
+                } catch (RuntimeException ex) {
+                  Toast.error(MainFrame.this, "Explorateur indisponible: " + ex.getMessage());
+                }
+              }
+            });
     JMenuItem manageUnav =
         new JMenuItem(
             new AbstractAction("Gérer les indisponibilités…") {
@@ -560,6 +572,7 @@ public class MainFrame extends JFrame {
     data.add(newUnav);
     data.add(newRecurring);
     data.add(manageResources);
+    data.add(exploreResources);
     data.add(manageUnav);
     data.add(deleteIntervention);
     data.add(emailPdf);
@@ -706,6 +719,18 @@ public class MainFrame extends JFrame {
     settings.add(docTmpl);
     settings.add(docHtmlTmpl);
     settings.add(docWysiwyg);
+    settings.add(
+        new JMenuItem(
+            new AbstractAction("Types de ressources…") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                try {
+                  new ResourceTypeManagerFrame(dsp).setVisible(true);
+                } catch (RuntimeException ex) {
+                  Toast.error(MainFrame.this, "Gestion des types indisponible: " + ex.getMessage());
+                }
+              }
+            }));
 
     JMenu tools = new JMenu("Outils");
     JMenuItem generateData = new JMenuItem("Générer des interventions…");

--- a/client/src/main/java/com/location/client/ui/ResourceExplorerFrame.java
+++ b/client/src/main/java/com/location/client/ui/ResourceExplorerFrame.java
@@ -1,0 +1,645 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import com.location.client.core.Models;
+import com.location.client.ui.accordion.CollapsibleSection;
+import com.location.client.ui.icons.SvgIconLoader;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.swing.AbstractAction;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSpinner;
+import javax.swing.JSplitPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.ListCellRenderer;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingConstants;
+import javax.swing.table.DefaultTableModel;
+
+public class ResourceExplorerFrame extends JFrame {
+  private final DataSourceProvider dataSourceProvider;
+  private final JComboBox<String> cbFilter = new JComboBox<>();
+  private final JPanel accordion = new JPanel();
+  private final JPanel detailPanel = new JPanel(new BorderLayout());
+  private final Models.ResourceType fallbackType = new Models.ResourceType(null, "Sans type", "hook.svg");
+  private List<Models.ResourceType> availableTypes = new ArrayList<>();
+  private boolean typeSupport = true;
+
+  public ResourceExplorerFrame(DataSourceProvider dsp) {
+    super("Ressources — Explorer & Configurer");
+    this.dataSourceProvider = dsp;
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setLayout(new BorderLayout(8, 8));
+
+    JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT));
+    header.add(new JLabel("Filtrer par type:"));
+    cbFilter.addActionListener(e -> buildAccordion());
+    header.add(cbFilter);
+    JButton btNew = new JButton(new AbstractAction("Nouvelle ressource") {
+      @Override
+      public void actionPerformed(java.awt.event.ActionEvent e) {
+        createResource();
+      }
+    });
+    header.add(btNew);
+    add(header, BorderLayout.NORTH);
+
+    accordion.setLayout(new javax.swing.BoxLayout(accordion, javax.swing.BoxLayout.Y_AXIS));
+    JScrollPane scroll = new JScrollPane(accordion);
+    detailPanel.add(new JLabel("Sélectionnez une ressource pour afficher les détails."), BorderLayout.CENTER);
+    JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scroll, detailPanel);
+    split.setResizeWeight(0.6);
+    add(split, BorderLayout.CENTER);
+
+    setSize(1100, 650);
+    setLocationRelativeTo(null);
+
+    reloadTypes();
+    refreshFilterItems(null);
+    buildAccordion();
+  }
+
+  private void reloadTypes() {
+    if (!typeSupport) {
+      availableTypes = List.of();
+      return;
+    }
+    try {
+      availableTypes = new ArrayList<>(dataSourceProvider.listResourceTypes());
+      availableTypes.sort(Comparator.comparing(Models.ResourceType::name, String.CASE_INSENSITIVE_ORDER));
+    } catch (UnsupportedOperationException ex) {
+      typeSupport = false;
+      availableTypes = List.of();
+      cbFilter.setEnabled(false);
+    }
+  }
+
+  private void refreshFilterItems(String preferredSelection) {
+    cbFilter.removeAllItems();
+    cbFilter.addItem("TOUS");
+    if (typeSupport && !availableTypes.isEmpty()) {
+      for (Models.ResourceType type : availableTypes) {
+        cbFilter.addItem(type.name());
+      }
+    }
+    cbFilter.addItem(fallbackType.name());
+    if (preferredSelection != null) {
+      for (int i = 0; i < cbFilter.getItemCount(); i++) {
+        if (preferredSelection.equals(cbFilter.getItemAt(i))) {
+          cbFilter.setSelectedIndex(i);
+          return;
+        }
+      }
+    }
+    cbFilter.setSelectedIndex(0);
+  }
+
+  private void buildAccordion() {
+    String previousFilter = cbFilter.getSelectedItem() == null ? null : cbFilter.getSelectedItem().toString();
+    reloadTypes();
+    refreshFilterItems(previousFilter);
+    accordion.removeAll();
+    Map<String, Models.ResourceType> typeById =
+        availableTypes.stream().collect(Collectors.toMap(Models.ResourceType::id, t -> t));
+    Map<String, List<Models.Resource>> grouped = new HashMap<>();
+    String filter = cbFilter.getSelectedItem() == null ? "TOUS" : cbFilter.getSelectedItem().toString();
+    for (Models.Resource resource : dataSourceProvider.listResources()) {
+      Models.ResourceType type = null;
+      if (typeSupport) {
+        String typeId = getTypeId(resource.id());
+        if (typeId != null) {
+          type = typeById.get(typeId);
+        }
+      }
+      String typeName = type == null ? fallbackType.name() : type.name();
+      if (!"TOUS".equals(filter) && !typeName.equals(filter)) {
+        continue;
+      }
+      grouped.computeIfAbsent(typeName, k -> new ArrayList<>()).add(resource);
+    }
+
+    List<String> orderedKeys = new ArrayList<>(grouped.keySet());
+    orderedKeys.sort(String.CASE_INSENSITIVE_ORDER);
+    for (String typeName : orderedKeys) {
+      List<Models.Resource> resources = grouped.get(typeName);
+      CollapsibleSection section = new CollapsibleSection(typeName + " (" + resources.size() + ")");
+      section.setExpanded(true);
+      JPanel list = new JPanel();
+      list.setLayout(new javax.swing.BoxLayout(list, javax.swing.BoxLayout.Y_AXIS));
+      for (Models.Resource resource : resources) {
+        JButton row = new JButton(resource.name() + "  —  " + nullToEmpty(resource.licensePlate()));
+        row.setHorizontalAlignment(SwingConstants.LEFT);
+        row.setBackground(Color.WHITE);
+        row.setOpaque(true);
+        row.setBorder(javax.swing.BorderFactory.createEmptyBorder(6, 8, 6, 8));
+        row.addActionListener(e -> showDetails(resource));
+        Models.ResourceType type = findTypeByName(typeName);
+        ImageIcon icon = SvgIconLoader.load(type == null ? fallbackType.iconName() : type.iconName(), 18);
+        row.setIcon(icon);
+        list.add(row);
+      }
+      section.setContent(list);
+      accordion.add(section);
+    }
+    accordion.add(javax.swing.Box.createVerticalGlue());
+    accordion.revalidate();
+    accordion.repaint();
+    detailPanel.revalidate();
+    detailPanel.repaint();
+  }
+
+  private Models.ResourceType findTypeByName(String name) {
+    if (name == null) {
+      return null;
+    }
+    for (Models.ResourceType type : availableTypes) {
+      if (type.name().equals(name)) {
+        return type;
+      }
+    }
+    if (fallbackType.name().equals(name)) {
+      return fallbackType;
+    }
+    return null;
+  }
+
+  private String getTypeId(String resourceId) {
+    if (!typeSupport) {
+      return null;
+    }
+    try {
+      return dataSourceProvider.getResourceTypeForResource(resourceId);
+    } catch (UnsupportedOperationException ex) {
+      typeSupport = false;
+      cbFilter.setEnabled(false);
+      return null;
+    }
+  }
+
+  private void createResource() {
+    Models.ResourceType chosenType = null;
+    if (typeSupport && !availableTypes.isEmpty()) {
+      DefaultComboBoxModel<Models.ResourceType> model =
+          new DefaultComboBoxModel<>(availableTypes.toArray(new Models.ResourceType[0]));
+      JComboBox<Models.ResourceType> combo = new JComboBox<>(model);
+      combo.setRenderer(typeRenderer());
+      int option =
+          JOptionPane.showConfirmDialog(
+              this,
+              combo,
+              "Type de ressource",
+              JOptionPane.OK_CANCEL_OPTION,
+              JOptionPane.QUESTION_MESSAGE);
+      if (option == JOptionPane.OK_OPTION) {
+        chosenType = (Models.ResourceType) combo.getSelectedItem();
+      } else {
+        return;
+      }
+    }
+    Models.Resource saved =
+        dataSourceProvider.saveResource(
+            new Models.Resource(
+                null,
+                "Nouvelle ressource",
+                "",
+                0x5096FF,
+                dataSourceProvider.getCurrentAgencyId(),
+                "",
+                null));
+    if (typeSupport && chosenType != null) {
+      try {
+        dataSourceProvider.setResourceTypeForResource(saved.id(), chosenType.id());
+      } catch (UnsupportedOperationException ex) {
+        Toast.error(this, "Attribution de type indisponible: " + ex.getMessage());
+        typeSupport = false;
+      }
+    }
+    buildAccordion();
+    showDetails(saved);
+  }
+
+  private ListCellRenderer<? super Models.ResourceType> typeRenderer() {
+    return new DefaultListCellRenderer() {
+      @Override
+      public Component getListCellRendererComponent(
+          javax.swing.JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+        JLabel base =
+            (JLabel)
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+        if (value instanceof Models.ResourceType type) {
+          base.setText(type.name());
+        } else {
+          base.setText(fallbackType.name());
+        }
+        return base;
+      }
+    };
+  }
+
+  private void showDetails(Models.Resource resource) {
+    detailPanel.removeAll();
+    detailPanel.add(
+        new ResourceSidePanel(
+            dataSourceProvider, resource, availableTypes, typeSupport, this::onResourceUpdated),
+        BorderLayout.CENTER);
+    detailPanel.revalidate();
+    detailPanel.repaint();
+  }
+
+  private void onResourceUpdated(Models.Resource updated) {
+    buildAccordion();
+    Toast.success(this, "Ressource mise à jour");
+    showDetails(updated);
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static class ResourceSidePanel extends JPanel {
+    private final DataSourceProvider dataSourceProvider;
+    private Models.Resource resource;
+    private final List<Models.ResourceType> types;
+    private final boolean typesSupported;
+    private final Consumer<Models.Resource> callback;
+    private final JTextField tfName = new JTextField(18);
+    private final JTextField tfPlate = new JTextField(10);
+    private final JTextField tfTags = new JTextField(18);
+    private final JSpinner spCapacity = new JSpinner(new SpinnerNumberModel(0, 0, 1000, 1));
+    private final JTextField tfRate = new JTextField(8);
+    private final JButton btColor = new JButton("Couleur…");
+    private final JComboBox<Models.ResourceType> cbType = new JComboBox<>();
+    private final JLabel lbTypeIcon = new JLabel();
+    private Integer colorRgb;
+    private boolean rateSupported = true;
+    private final DefaultTableModel unavailabilityModel =
+        new DefaultTableModel(new Object[] {"Début", "Fin", "Motif"}, 0) {
+          @Override
+          public boolean isCellEditable(int row, int column) {
+            return false;
+          }
+        };
+    private final JTable unavailabilityTable = new JTable(unavailabilityModel);
+    private List<Models.Unavailability> unavailabilityCache = List.of();
+    private final DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm", Locale.FRENCH).withZone(ZoneId.systemDefault());
+
+    ResourceSidePanel(
+        DataSourceProvider dsp,
+        Models.Resource resource,
+        List<Models.ResourceType> types,
+        boolean typesSupported,
+        Consumer<Models.Resource> callback) {
+      super(new BorderLayout(8, 8));
+      this.dataSourceProvider = dsp;
+      this.resource = resource;
+      this.types = new ArrayList<>(types);
+      this.typesSupported = typesSupported;
+      this.callback = callback;
+
+      JPanel form = new JPanel(new GridBagLayout());
+      GridBagConstraints c = new GridBagConstraints();
+      c.insets = new Insets(6, 6, 6, 6);
+      c.anchor = GridBagConstraints.WEST;
+      c.fill = GridBagConstraints.HORIZONTAL;
+      c.weightx = 1.0;
+      int y = 0;
+
+      addRow(form, c, y++, "Nom", tfName);
+      addRow(form, c, y++, "Plaque", tfPlate);
+      addRow(form, c, y++, "Tags", tfTags);
+      addRow(form, c, y++, "Capacité (t)", spCapacity);
+      addRow(form, c, y++, "Prix/jour (€)", tfRate);
+
+      JPanel colorPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+      colorPanel.add(btColor);
+      addRow(form, c, y++, "Couleur", colorPanel);
+
+      JPanel typePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+      typePanel.add(cbType);
+      typePanel.add(lbTypeIcon);
+      addRow(form, c, y++, "Type", typePanel);
+
+      add(form, BorderLayout.NORTH);
+
+      btColor.setFocusPainted(false);
+      btColor.addActionListener(e -> chooseColor());
+      lbTypeIcon.setPreferredSize(new java.awt.Dimension(36, 36));
+
+      configureTypeCombo();
+
+      JPanel bottom = new JPanel(new BorderLayout());
+      bottom.setBorder(javax.swing.BorderFactory.createTitledBorder("Indisponibilités"));
+      unavailabilityTable.setRowHeight(24);
+      bottom.add(new JScrollPane(unavailabilityTable), BorderLayout.CENTER);
+      JToolBar toolbar = new JToolBar();
+      toolbar.setFloatable(false);
+      toolbar.add(new JButton(new AbstractAction("Ajouter") {
+        @Override
+        public void actionPerformed(java.awt.event.ActionEvent e) {
+          addUnavailability();
+        }
+      }));
+      toolbar.add(new JButton(new AbstractAction("Supprimer") {
+        @Override
+        public void actionPerformed(java.awt.event.ActionEvent e) {
+          deleteUnavailability();
+        }
+      }));
+      bottom.add(toolbar, BorderLayout.NORTH);
+      add(bottom, BorderLayout.CENTER);
+
+      JButton btSave = new JButton(new AbstractAction("Enregistrer") {
+        @Override
+        public void actionPerformed(java.awt.event.ActionEvent e) {
+          save();
+        }
+      });
+      JPanel south = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+      south.add(btSave);
+      add(south, BorderLayout.SOUTH);
+
+      load();
+    }
+
+    private void configureTypeCombo() {
+      cbType.setRenderer(
+          new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(
+                javax.swing.JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+              JLabel base =
+                  (JLabel)
+                      super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+              if (value instanceof Models.ResourceType type) {
+                base.setText(type.name());
+              } else {
+                base.setText("(aucun)");
+              }
+              return base;
+            }
+          });
+      cbType.removeAllItems();
+      cbType.addItem(null);
+      if (typesSupported) {
+        for (Models.ResourceType type : types) {
+          cbType.addItem(type);
+        }
+      } else {
+        cbType.setEnabled(false);
+      }
+      cbType.addActionListener(e -> updateTypeIcon());
+      updateTypeIcon();
+    }
+
+    private void addRow(JPanel panel, GridBagConstraints c, int row, String label, Component field) {
+      c.gridx = 0;
+      c.gridy = row;
+      c.weightx = 0;
+      c.fill = GridBagConstraints.NONE;
+      panel.add(new JLabel(label), c);
+      c.gridx = 1;
+      c.weightx = 1.0;
+      c.fill = GridBagConstraints.HORIZONTAL;
+      panel.add(field, c);
+    }
+
+    private void load() {
+      tfName.setText(resource.name());
+      tfPlate.setText(resource.licensePlate());
+      tfTags.setText(resource.tags());
+      spCapacity.setValue(resource.capacityTons() == null ? 0 : resource.capacityTons());
+      colorRgb = resource.colorRgb();
+      updateColorButton();
+      loadRate();
+      selectCurrentType();
+      loadUnavailabilities();
+    }
+
+    private void loadRate() {
+      try {
+        double rate = dataSourceProvider.getResourceDailyRate(resource.id());
+        tfRate.setText(String.format(Locale.FRENCH, "%.2f", rate));
+      } catch (UnsupportedOperationException ex) {
+        tfRate.setText("N/A");
+        tfRate.setEnabled(false);
+        rateSupported = false;
+      }
+    }
+
+    private void selectCurrentType() {
+      if (!typesSupported) {
+        return;
+      }
+      try {
+        String typeId = dataSourceProvider.getResourceTypeForResource(resource.id());
+        if (typeId == null) {
+          cbType.setSelectedItem(null);
+          return;
+        }
+        for (int i = 0; i < cbType.getItemCount(); i++) {
+          Models.ResourceType item = cbType.getItemAt(i);
+          if (item != null && typeId.equals(item.id())) {
+            cbType.setSelectedItem(item);
+            return;
+          }
+        }
+        cbType.setSelectedItem(null);
+      } catch (UnsupportedOperationException ex) {
+        cbType.setEnabled(false);
+      }
+    }
+
+    private void loadUnavailabilities() {
+      try {
+        unavailabilityCache = dataSourceProvider.listUnavailability(resource.id());
+      } catch (UnsupportedOperationException ex) {
+        unavailabilityCache = List.of();
+      }
+      unavailabilityModel.setRowCount(0);
+      for (Models.Unavailability u : unavailabilityCache) {
+        unavailabilityModel.addRow(
+            new Object[] {
+              formatter.format(u.start()),
+              formatter.format(u.end()),
+              u.reason() == null ? "" : u.reason()
+            });
+      }
+    }
+
+    private void addUnavailability() {
+      String startRaw =
+          JOptionPane.showInputDialog(
+              this,
+              "Début (AAAA-MM-JJ HH:MM)",
+              LocalDateTime.now().withSecond(0).withNano(0).toString().replace('T', ' '));
+      if (startRaw == null) {
+        return;
+      }
+      String endRaw =
+          JOptionPane.showInputDialog(
+              this,
+              "Fin (AAAA-MM-JJ HH:MM)",
+              LocalDateTime.now().plusHours(1).withSecond(0).withNano(0).toString().replace('T', ' '));
+      if (endRaw == null) {
+        return;
+      }
+      LocalDateTime start;
+      LocalDateTime end;
+      try {
+        start = parseDateTime(startRaw);
+        end = parseDateTime(endRaw);
+      } catch (DateTimeParseException ex) {
+        JOptionPane.showMessageDialog(this, "Format de date invalide", "Erreur", JOptionPane.ERROR_MESSAGE);
+        return;
+      }
+      if (!end.isAfter(start)) {
+        JOptionPane.showMessageDialog(
+            this, "La date de fin doit être postérieure au début", "Erreur", JOptionPane.ERROR_MESSAGE);
+        return;
+      }
+      String reason =
+          JOptionPane.showInputDialog(this, "Motif", "Indisponibilité", JOptionPane.QUESTION_MESSAGE);
+      if (reason == null) {
+        return;
+      }
+      Instant startInstant = start.atZone(ZoneId.systemDefault()).toInstant();
+      Instant endInstant = end.atZone(ZoneId.systemDefault()).toInstant();
+      try {
+        dataSourceProvider.saveUnavailability(
+            new Models.Unavailability(null, resource.id(), reason, startInstant, endInstant, false));
+        loadUnavailabilities();
+        Toast.success(this, "Indisponibilité ajoutée");
+      } catch (RuntimeException ex) {
+        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      }
+    }
+
+    private LocalDateTime parseDateTime(String raw) {
+      String normalized = raw.trim().replace('T', ' ');
+      return LocalDateTime.parse(normalized, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
+
+    private void deleteUnavailability() {
+      int row = unavailabilityTable.getSelectedRow();
+      if (row < 0 || row >= unavailabilityCache.size()) {
+        return;
+      }
+      Models.Unavailability selected = unavailabilityCache.get(row);
+      try {
+        dataSourceProvider.deleteUnavailability(selected.id());
+        loadUnavailabilities();
+        Toast.info(this, "Indisponibilité supprimée");
+      } catch (RuntimeException ex) {
+        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      }
+    }
+
+    private void chooseColor() {
+      Color initial = colorRgb == null ? new Color(0x5096FF) : new Color(colorRgb);
+      Color chosen = javax.swing.JColorChooser.showDialog(this, "Couleur", initial);
+      if (chosen != null) {
+        colorRgb = chosen.getRGB() & 0xFFFFFF;
+        updateColorButton();
+      }
+    }
+
+    private void updateColorButton() {
+      Color display = colorRgb == null ? new Color(0x5096FF) : new Color(colorRgb);
+      btColor.setBackground(display);
+      btColor.setForeground(display.getRGB() < 0x7F7F7F ? Color.WHITE : Color.BLACK);
+      btColor.setOpaque(true);
+    }
+
+    private void updateTypeIcon() {
+      Models.ResourceType selected = (Models.ResourceType) cbType.getSelectedItem();
+      String iconName = selected == null ? fallbackType.iconName() : selected.iconName();
+      lbTypeIcon.setIcon(SvgIconLoader.load(iconName, 32));
+    }
+
+    private void save() {
+      String name = tfName.getText().trim();
+      if (name.isEmpty()) {
+        JOptionPane.showMessageDialog(this, "Nom obligatoire", "Validation", JOptionPane.WARNING_MESSAGE);
+        return;
+      }
+      String plate = tfPlate.getText().trim();
+      String tags = tfTags.getText().trim();
+      Integer capacity = (Integer) spCapacity.getValue();
+      if (capacity != null && capacity == 0) {
+        capacity = null;
+      }
+      Double rateValue = null;
+      if (rateSupported) {
+        String rateRaw = tfRate.getText().trim().replace(',', '.');
+        if (!rateRaw.isEmpty()) {
+          try {
+            rateValue = Double.parseDouble(rateRaw);
+          } catch (NumberFormatException ex) {
+            JOptionPane.showMessageDialog(
+                this, "Prix invalide", "Validation", JOptionPane.WARNING_MESSAGE);
+            return;
+          }
+        }
+      }
+
+      Models.Resource updated =
+          new Models.Resource(
+              resource.id(),
+              name,
+              plate,
+              colorRgb,
+              resource.agencyId(),
+              tags,
+              capacity);
+      try {
+        resource = dataSourceProvider.saveResource(updated);
+        if (rateSupported) {
+          double effectiveRate = rateValue == null ? 0.0 : rateValue;
+          dataSourceProvider.setResourceDailyRate(resource.id(), effectiveRate);
+        }
+        if (typesSupported) {
+          Models.ResourceType selected = (Models.ResourceType) cbType.getSelectedItem();
+          String typeId = selected == null ? null : selected.id();
+          dataSourceProvider.setResourceTypeForResource(resource.id(), typeId);
+        }
+        if (callback != null) {
+          callback.accept(resource);
+        }
+      } catch (UnsupportedOperationException ex) {
+        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      } catch (RuntimeException ex) {
+        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      }
+    }
+  }
+}

--- a/client/src/main/java/com/location/client/ui/ResourceTypeManagerFrame.java
+++ b/client/src/main/java/com/location/client/ui/ResourceTypeManagerFrame.java
@@ -1,0 +1,277 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import com.location.client.core.Models;
+import com.location.client.ui.icons.SvgIconLoader;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Insets;
+import javax.swing.AbstractAction;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.ListSelectionModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+
+public class ResourceTypeManagerFrame extends JFrame {
+  private final DataSourceProvider dataSourceProvider;
+  private final DefaultTableModel model =
+      new DefaultTableModel(new Object[] {"ID", "Nom", "Icône"}, 0) {
+        @Override
+        public boolean isCellEditable(int row, int column) {
+          return false;
+        }
+      };
+  private final JTable table = new JTable(model);
+  private final JTextField tfName = new JTextField(20);
+  private final javax.swing.JComboBox<String> cbIcon = new javax.swing.JComboBox<>();
+  private final JLabel iconPreview = new JLabel();
+  private Models.ResourceType current;
+  private boolean supported = true;
+  private boolean notifiedUnsupported;
+
+  public ResourceTypeManagerFrame(DataSourceProvider dsp) {
+    super("Types de ressources");
+    this.dataSourceProvider = dsp;
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setLayout(new BorderLayout(8, 8));
+
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    table.setRowHeight(28);
+    table.getColumnModel()
+        .getColumn(2)
+        .setCellRenderer(
+            new DefaultTableCellRenderer() {
+              @Override
+              public Component getTableCellRendererComponent(
+                  JTable table,
+                  Object value,
+                  boolean isSelected,
+                  boolean hasFocus,
+                  int row,
+                  int column) {
+                JLabel base =
+                    (JLabel)
+                        super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+                String icon = value == null ? null : value.toString();
+                base.setText(icon);
+                base.setIcon(SvgIconLoader.load(icon, 20));
+                return base;
+              }
+            });
+    table.getSelectionModel().addListSelectionListener(e -> {
+      if (!e.getValueIsAdjusting()) {
+        onTableSelection();
+      }
+    });
+
+    JScrollPane scroll = new JScrollPane(table);
+    scroll.setPreferredSize(new Dimension(360, 240));
+
+    JToolBar toolbar = new JToolBar();
+    toolbar.setFloatable(false);
+    toolbar.add(new JButton(new AbstractAction("Nouveau") {
+      @Override
+      public void actionPerformed(java.awt.event.ActionEvent e) {
+        select(null);
+      }
+    }));
+    toolbar.add(new JButton(new AbstractAction("Supprimer") {
+      @Override
+      public void actionPerformed(java.awt.event.ActionEvent e) {
+        deleteType();
+      }
+    }));
+
+    JPanel left = new JPanel(new BorderLayout());
+    left.add(toolbar, BorderLayout.NORTH);
+    left.add(scroll, BorderLayout.CENTER);
+
+    JPanel form = new JPanel(new java.awt.GridBagLayout());
+    java.awt.GridBagConstraints c = new java.awt.GridBagConstraints();
+    c.insets = new Insets(6, 6, 6, 6);
+    c.anchor = java.awt.GridBagConstraints.WEST;
+    c.gridx = 0;
+    c.gridy = 0;
+    form.add(new JLabel("Nom"), c);
+    c.gridx = 1;
+    c.fill = java.awt.GridBagConstraints.HORIZONTAL;
+    c.weightx = 1.0;
+    form.add(tfName, c);
+
+    c.gridx = 0;
+    c.gridy = 1;
+    c.weightx = 0;
+    c.fill = java.awt.GridBagConstraints.NONE;
+    form.add(new JLabel("Icône"), c);
+    c.gridx = 1;
+    c.fill = java.awt.GridBagConstraints.HORIZONTAL;
+    form.add(cbIcon, c);
+
+    c.gridy = 2;
+    form.add(iconPreview, c);
+
+    iconPreview.setPreferredSize(new Dimension(64, 64));
+
+    JButton btSave = new JButton(new AbstractAction("Enregistrer") {
+      @Override
+      public void actionPerformed(java.awt.event.ActionEvent e) {
+        saveType();
+      }
+    });
+
+    JPanel right = new JPanel(new BorderLayout(8, 8));
+    right.add(form, BorderLayout.CENTER);
+    right.add(btSave, BorderLayout.SOUTH);
+
+    add(left, BorderLayout.CENTER);
+    add(right, BorderLayout.EAST);
+
+    cbIcon.setModel(new DefaultComboBoxModel<>(SvgIconLoader.listAvailable().toArray(new String[0])));
+    cbIcon.addActionListener(e -> updatePreview());
+    updatePreview();
+
+    setSize(720, 360);
+    setLocationRelativeTo(null);
+    refresh();
+  }
+
+  private void onTableSelection() {
+    int row = table.getSelectedRow();
+    if (row < 0) {
+      select(null);
+      return;
+    }
+    String id = value(row, 0);
+    String name = value(row, 1);
+    String icon = value(row, 2);
+    current = new Models.ResourceType(id, name, icon);
+    tfName.setText(name);
+    cbIcon.setSelectedItem(icon);
+    updatePreview();
+  }
+
+  private String value(int row, int column) {
+    Object val = model.getValueAt(row, column);
+    return val == null ? "" : val.toString();
+  }
+
+  private void select(Models.ResourceType type) {
+    current = type;
+    tfName.setText(type == null ? "" : type.name());
+    if (type == null) {
+      cbIcon.setSelectedIndex(0);
+    } else {
+      cbIcon.setSelectedItem(type.iconName());
+    }
+    table.clearSelection();
+    updatePreview();
+  }
+
+  private void refresh() {
+    if (!supported) {
+      return;
+    }
+    try {
+      model.setRowCount(0);
+      for (Models.ResourceType type : dataSourceProvider.listResourceTypes()) {
+        model.addRow(new Object[] {type.id(), type.name(), type.iconName()});
+      }
+      if (model.getRowCount() > 0) {
+        table.setRowSelectionInterval(0, 0);
+      } else {
+        select(null);
+      }
+    } catch (UnsupportedOperationException ex) {
+      handleUnsupported(ex);
+    }
+  }
+
+  private void saveType() {
+    if (!supported) {
+      return;
+    }
+    String name = tfName.getText().trim();
+    if (name.isEmpty()) {
+      JOptionPane.showMessageDialog(this, "Nom obligatoire", "Validation", JOptionPane.WARNING_MESSAGE);
+      return;
+    }
+    String icon = cbIcon.getSelectedItem() == null ? null : cbIcon.getSelectedItem().toString();
+    try {
+      Models.ResourceType saved =
+          dataSourceProvider.saveResourceType(
+              new Models.ResourceType(current == null ? null : current.id(), name, icon));
+      current = saved;
+      refresh();
+      Toast.success(this, "Type enregistré");
+    } catch (UnsupportedOperationException ex) {
+      handleUnsupported(ex);
+    } catch (RuntimeException ex) {
+      JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+    }
+  }
+
+  private void deleteType() {
+    if (!supported) {
+      return;
+    }
+    int row = table.getSelectedRow();
+    if (row < 0) {
+      return;
+    }
+    String id = value(row, 0);
+    if (id.isBlank()) {
+      return;
+    }
+    int confirm =
+        JOptionPane.showConfirmDialog(
+            this,
+            "Supprimer ce type ? Les ressources associées perdront ce type.",
+            "Confirmation",
+            JOptionPane.OK_CANCEL_OPTION);
+    if (confirm != JOptionPane.OK_OPTION) {
+      return;
+    }
+    try {
+      dataSourceProvider.deleteResourceType(id);
+      refresh();
+      Toast.info(this, "Type supprimé");
+    } catch (UnsupportedOperationException ex) {
+      handleUnsupported(ex);
+    } catch (RuntimeException ex) {
+      JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+    }
+  }
+
+  private void updatePreview() {
+    String icon = cbIcon.getSelectedItem() == null ? null : cbIcon.getSelectedItem().toString();
+    ImageIcon img = SvgIconLoader.load(icon, 48);
+    iconPreview.setIcon(img);
+  }
+
+  private void handleUnsupported(RuntimeException ex) {
+    supported = false;
+    table.setEnabled(false);
+    tfName.setEnabled(false);
+    cbIcon.setEnabled(false);
+    if (!notifiedUnsupported) {
+      JOptionPane.showMessageDialog(
+          this,
+          "Gestion des types indisponible pour cette source de données." +
+              (ex.getMessage() == null ? "" : "\n" + ex.getMessage()),
+          "Information",
+          JOptionPane.INFORMATION_MESSAGE);
+      notifiedUnsupported = true;
+    }
+  }
+}

--- a/client/src/main/java/com/location/client/ui/accordion/CollapsibleSection.java
+++ b/client/src/main/java/com/location/client/ui/accordion/CollapsibleSection.java
@@ -1,0 +1,52 @@
+package com.location.client.ui.accordion;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+public class CollapsibleSection extends JPanel {
+  private final JPanel header = new JPanel(new BorderLayout());
+  private final JButton toggle = new JButton();
+  private final JLabel title = new JLabel();
+  private final JPanel content = new JPanel(new BorderLayout());
+  private boolean expanded;
+
+  public CollapsibleSection(String text) {
+    super(new BorderLayout());
+    toggle.setBorder(BorderFactory.createEmptyBorder(2, 6, 2, 6));
+    toggle.setContentAreaFilled(false);
+    toggle.setFocusPainted(false);
+    header.add(toggle, BorderLayout.WEST);
+    header.add(title, BorderLayout.CENTER);
+    header.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.LIGHT_GRAY));
+    add(header, BorderLayout.NORTH);
+    add(content, BorderLayout.CENTER);
+    setExpanded(false);
+    setTitle(text);
+    toggle.addActionListener(e -> setExpanded(!expanded));
+  }
+
+  public void setTitle(String text) {
+    title.setText(text);
+  }
+
+  public void setContent(Component component) {
+    content.removeAll();
+    if (component != null) {
+      content.add(component, BorderLayout.CENTER);
+    }
+    content.revalidate();
+    content.repaint();
+  }
+
+  public void setExpanded(boolean on) {
+    expanded = on;
+    toggle.setText(on ? "▾" : "▸");
+    content.setVisible(on);
+    revalidate();
+  }
+}

--- a/client/src/main/java/com/location/client/ui/icons/SvgIconLoader.java
+++ b/client/src/main/java/com/location/client/ui/icons/SvgIconLoader.java
@@ -1,0 +1,82 @@
+package com.location.client.ui.icons;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.ImageIcon;
+import org.apache.batik.transcoder.TranscoderException;
+import org.apache.batik.transcoder.TranscoderInput;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.ImageTranscoder;
+
+public final class SvgIconLoader {
+  private static final String ICONS_BASE = "/icons/";
+
+  private SvgIconLoader() {}
+
+  public static ImageIcon load(String iconName, int size) {
+    if (iconName == null || iconName.isBlank()) {
+      return null;
+    }
+    try (InputStream in = SvgIconLoader.class.getResourceAsStream(ICONS_BASE + iconName)) {
+      if (in == null) {
+        return null;
+      }
+      BufferedImage img = rasterize(in, size, size);
+      return new ImageIcon(img);
+    } catch (IOException | TranscoderException ex) {
+      return null;
+    }
+  }
+
+  private static BufferedImage rasterize(InputStream in, int width, int height) throws TranscoderException {
+    class BufferedImageTranscoderImpl extends ImageTranscoder {
+      private BufferedImage image;
+
+      @Override
+      public BufferedImage createImage(int w, int h) {
+        return new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+      }
+
+      @Override
+      public void writeImage(BufferedImage img, TranscoderOutput out) {
+        this.image = img;
+      }
+
+      BufferedImage getImage() {
+        return image;
+      }
+    }
+
+    BufferedImageTranscoderImpl transcoder = new BufferedImageTranscoderImpl();
+    transcoder.addTranscodingHint(ImageTranscoder.KEY_WIDTH, (float) width);
+    transcoder.addTranscodingHint(ImageTranscoder.KEY_HEIGHT, (float) height);
+    transcoder.transcode(new TranscoderInput(in), null);
+    return transcoder.getImage();
+  }
+
+  public static List<String> listAvailable() {
+    try (InputStream in = SvgIconLoader.class.getResourceAsStream(ICONS_BASE + "icons.txt")) {
+      if (in == null) {
+        return defaultIcons();
+      }
+      String content = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+      List<String> icons = new ArrayList<>();
+      for (String line : content.split("\n")) {
+        String trimmed = line.trim();
+        if (!trimmed.isBlank()) {
+          icons.add(trimmed);
+        }
+      }
+      return icons.isEmpty() ? defaultIcons() : icons;
+    } catch (IOException ex) {
+      return defaultIcons();
+    }
+  }
+
+  private static List<String> defaultIcons() {
+    return List.of("crane.svg", "truck.svg", "trailer.svg", "forklift.svg", "excavator.svg", "hook.svg");
+  }
+}

--- a/client/src/main/resources/icons/crane.svg
+++ b/client/src/main/resources/icons/crane.svg
@@ -1,4 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path d="M3 20h18v2H3zM5 20V8l6-6h8v4h-6l-4 4v10"/>
-  <path d="M19 8h-8l-2 2h10z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <path d="M6 56h52v4H6z" fill="#555"/>
+  <rect x="12" y="26" width="6" height="24" fill="#777"/>
+  <rect x="18" y="22" width="6" height="28" fill="#888"/>
+  <path d="M24 22h28l6-6H24z" fill="#999"/>
+  <circle cx="52" cy="16" r="3" fill="#666"/>
+  <rect x="40" y="28" width="8" height="10" fill="#bbb"/>
+  <rect x="32" y="38" width="24" height="2" fill="#999"/>
+  <rect x="46" y="40" width="2" height="10" fill="#999"/>
+  <circle cx="24" cy="58" r="3" fill="#333"/>
+  <circle cx="44" cy="58" r="3" fill="#333"/>
 </svg>

--- a/client/src/main/resources/icons/excavator.svg
+++ b/client/src/main/resources/icons/excavator.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <rect x="12" y="30" width="14" height="8" fill="#f57c00"/>
+  <rect x="26" y="34" width="20" height="6" fill="#ef6c00"/>
+  <rect x="46" y="24" width="6" height="16" fill="#bf360c"/>
+  <rect x="52" y="20" width="4" height="6" fill="#8d6e63"/>
+  <rect x="54" y="26" width="6" height="2" fill="#6d4c41"/>
+  <circle cx="18" cy="48" r="4" fill="#333"/>
+  <circle cx="38" cy="48" r="4" fill="#333"/>
+</svg>

--- a/client/src/main/resources/icons/forklift.svg
+++ b/client/src/main/resources/icons/forklift.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <rect x="22" y="26" width="16" height="12" fill="#ffb300"/>
+  <rect x="16" y="38" width="22" height="6" fill="#ffa000"/>
+  <rect x="38" y="26" width="4" height="18" fill="#8d6e63"/>
+  <rect x="42" y="40" width="12" height="2" fill="#6d4c41"/>
+  <circle cx="20" cy="48" r="4" fill="#333"/>
+  <circle cx="36" cy="48" r="4" fill="#333"/>
+</svg>

--- a/client/src/main/resources/icons/hook.svg
+++ b/client/src/main/resources/icons/hook.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <circle cx="32" cy="18" r="8" fill="#90a4ae"/>
+  <rect x="30" y="26" width="4" height="12" fill="#90a4ae"/>
+  <path d="M32 38c0 6-4 8-8 10" stroke="#455a64" stroke-width="3" fill="none"/>
+</svg>

--- a/client/src/main/resources/icons/icons.txt
+++ b/client/src/main/resources/icons/icons.txt
@@ -1,0 +1,6 @@
+crane.svg
+truck.svg
+trailer.svg
+forklift.svg
+excavator.svg
+hook.svg

--- a/client/src/main/resources/icons/trailer.svg
+++ b/client/src/main/resources/icons/trailer.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <rect x="8" y="28" width="44" height="10" fill="#8d6e63"/>
+  <rect x="8" y="38" width="44" height="6" fill="#6d4c41"/>
+  <circle cx="18" cy="48" r="3" fill="#333"/>
+  <circle cx="46" cy="48" r="3" fill="#333"/>
+</svg>

--- a/client/src/main/resources/icons/truck.svg
+++ b/client/src/main/resources/icons/truck.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <rect x="6" y="28" width="34" height="14" fill="#7f8c8d"/>
+  <rect x="40" y="28" width="18" height="10" fill="#95a5a6"/>
+  <rect x="42" y="30" width="8" height="6" fill="#cfd8dc"/>
+  <circle cx="18" cy="46" r="4" fill="#333"/>
+  <circle cx="50" cy="46" r="4" fill="#333"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Batik dependencies and an SVG loader to display resource type icons
- extend the mock data source with resource type management and daily rates
- add resource explorer/type manager UIs plus new SVG icons and menu entries

## Testing
- mvn -pl client -am -DskipTests compile *(fails: parent and Spring Boot BOM unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da50907d508330a27f2a06dead663f