### PR TITLE
Support multi-resource interventions in client data layer

### DIFF
--- a/client/src/main/java/com/location/client/core/Models.java
+++ b/client/src/main/java/com/location/client/core/Models.java
@@ -1,6 +1,7 @@
 package com.location.client.core;
 
 import java.time.Instant;
+import java.util.List;
 
 public final class Models {
   private Models() {}
@@ -28,13 +29,49 @@ public final class Models {
   public record Intervention(
       String id,
       String agencyId,
-      String resourceId,
+      List<String> resourceIds,
       String clientId,
       String driverId,
       String title,
       Instant start,
       Instant end,
-      String notes) {}
+      String notes) {
+    public Intervention {
+      this.resourceIds = resourceIds == null ? List.of() : List.copyOf(resourceIds);
+    }
+
+    public Intervention(
+        String id,
+        String agencyId,
+        String resourceId,
+        String clientId,
+        String driverId,
+        String title,
+        Instant start,
+        Instant end,
+        String notes) {
+      this(
+          id,
+          agencyId,
+          resourceId == null || resourceId.isBlank() ? List.of() : List.of(resourceId),
+          clientId,
+          driverId,
+          title,
+          start,
+          end,
+          notes);
+    }
+
+    public String resourceId() {
+      return resourceIds.isEmpty() ? null : resourceIds.get(0);
+    }
+
+    public Intervention withResourceIds(List<String> newResourceIds) {
+      return new Intervention(
+          id, agencyId, newResourceIds == null ? List.of() : List.copyOf(newResourceIds), clientId,
+          driverId, title, start, end, notes);
+    }
+  }
 
   public record Unavailability(
       String id,


### PR DESCRIPTION
## Summary
- allow interventions to store multiple resource identifiers while preserving compatibility with the legacy single-resource accessor
- update the mock data source to evaluate conflicts and unavailabilities against every associated resource identifier
- extend the REST client to emit and consume resource identifier arrays alongside the existing field so remote services can opt into multi-resource payloads

## Testing
- mvn -pl client -q -DskipTests compile *(fails: unable to download spring-boot-dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68da561356fc8330a7bed934d8e7cc24