### PR TITLE
Allow resource overlaps and seed richer demo data

### DIFF
--- a/client/src/main/java/com/location/client/core/MockDataSource.java
+++ b/client/src/main/java/com/location/client/core/MockDataSource.java
@@ -9,7 +9,6 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;
@@ -130,106 +129,174 @@ public class MockDataSource implements DataSourceProvider {
         .put("INVOICE", new Models.DocTemplate("<h1>Facture {{docRef}}</h1>"));
 
     Models.ResourceType typeGrue =
-        saveResourceType(new Models.ResourceType(null, "Grue", "crane.svg"));
+        saveResourceType(new Models.ResourceType(null, "GRUE", "crane.svg"));
     Models.ResourceType typeCamion =
-        saveResourceType(new Models.ResourceType(null, "Camion", "truck.svg"));
+        saveResourceType(new Models.ResourceType(null, "CAMION", "truck.svg"));
     Models.ResourceType typeRemorque =
-        saveResourceType(new Models.ResourceType(null, "Remorque", "trailer.svg"));
+        saveResourceType(new Models.ResourceType(null, "REMORQUE", "trailer.svg"));
+    Models.ResourceType typeNacelle =
+        saveResourceType(new Models.ResourceType(null, "NACELLE", "nacelle.svg"));
+    Models.ResourceType typeChauffeur =
+        saveResourceType(new Models.ResourceType(null, "CHAUFFEUR", "driver.svg"));
 
-    clients.add(new Models.Client(UUID.randomUUID().toString(), "Client Alpha", "alpha@acme.tld"));
-    clients.add(new Models.Client(UUID.randomUUID().toString(), "Client Beta", "beta@acme.tld"));
+    clients.add(
+        new Models.Client(
+            UUID.randomUUID().toString(), "Chantier Alpha", "alpha@chantier.test"));
+    clients.add(
+        new Models.Client(
+            UUID.randomUUID().toString(), "Chantier Beta", "beta@chantier.test"));
 
-    drivers.add(new Models.Driver(UUID.randomUUID().toString(), "Jean Dupont", "jean@loc.tld"));
-    drivers.add(new Models.Driver(UUID.randomUUID().toString(), "Sophie Martin", "sophie@loc.tld"));
+    drivers.add(new Models.Driver(UUID.randomUUID().toString(), "Jean Routier", "jean@loc.tld"));
+    drivers.add(new Models.Driver(UUID.randomUUID().toString(), "Alice Grutier", "alice@loc.tld"));
 
-    Models.Resource resGrue =
-        new Models.Resource(
-            UUID.randomUUID().toString(),
-            "Grue X",
-            "AB-123-CD",
-            0xFF4444,
-            a1.id(),
-            "grue,90t",
-            90);
-    Models.Resource resCamion =
-        new Models.Resource(
-            UUID.randomUUID().toString(),
-            "Camion Y",
-            "EF-456-GH",
-            0x44AA44,
-            a1.id(),
-            "camion,benne",
-            18);
-    Models.Resource resRemorque =
-        new Models.Resource(
-            UUID.randomUUID().toString(),
-            "Remorque Z",
-            "IJ-789-KL",
-            0x4444FF,
-            a2.id(),
-            "remorque,plateau",
-            10);
-    resources.add(resGrue);
-    resources.add(resCamion);
-    resources.add(resRemorque);
+    int[] palette = {0x4CAF50, 0xFF9800, 0x3F51B5, 0x009688, 0x9C27B0, 0x795548};
+    List<String> agencyIds = List.of(a1.id(), a2.id());
 
-    resourceTypeAssignments.put(resGrue.id(), typeGrue.id());
-    resourceTypeAssignments.put(resCamion.id(), typeCamion.id());
-    resourceTypeAssignments.put(resRemorque.id(), typeRemorque.id());
-    resourceDailyRates.put(resGrue.id(), 950.0);
-    resourceDailyRates.put(resCamion.id(), 520.0);
-    resourceDailyRates.put(resRemorque.id(), 310.0);
+    for (int i = 0; i < 6; i++) {
+      int height = 40 + 5 * i;
+      Models.Resource resource =
+          new Models.Resource(
+              UUID.randomUUID().toString(),
+              String.format("Grue %dm", height),
+              String.format("GR-%02d-%02d", 60 + i, 10 + i),
+              palette[i % palette.length],
+              agencyIds.get(i % agencyIds.size()),
+              String.format("grue,%dm", height),
+              height);
+      resources.add(resource);
+      resourceTypeAssignments.put(resource.id(), typeGrue.id());
+      resourceDailyRates.put(resource.id(), 700.0 + i * 80.0);
+    }
 
-    ZonedDateTime base =
-        ZonedDateTime.now(ZoneId.systemDefault()).withHour(9).withMinute(0).withSecond(0).withNano(0);
+    for (int i = 0; i < 6; i++) {
+      int tonnage = 10 + 2 * i;
+      Models.Resource resource =
+          new Models.Resource(
+              UUID.randomUUID().toString(),
+              String.format("Camion %dt", tonnage),
+              String.format("CA-%02d-%02d", 70 + i, 20 + i),
+              palette[(i + 1) % palette.length],
+              agencyIds.get((i + 1) % agencyIds.size()),
+              String.format("camion,%dt", tonnage),
+              tonnage);
+      resources.add(resource);
+      resourceTypeAssignments.put(resource.id(), typeCamion.id());
+      resourceDailyRates.put(resource.id(), 400.0 + i * 50.0);
+    }
 
-    addIntervention(
-        a1.id(),
-        resources.get(0).id(),
-        clients.get(0).id(),
-        drivers.get(0).id(),
-        "Livraison chantier",
-        base.plusDays(1).toInstant(),
-        base.plusDays(1).plusHours(2).toInstant(),
-        "Site A – prévoir EPI");
-    addIntervention(
-        a1.id(),
-        resources.get(1).id(),
-        clients.get(1).id(),
-        drivers.get(1).id(),
-        "Levage poutres",
-        base.plusDays(1).plusHours(3).toInstant(),
-        base.plusDays(1).plusHours(5).toInstant(),
-        null);
-    addIntervention(
-        a2.id(),
-        resources.get(2).id(),
-        clients.get(1).id(),
-        null,
-        "Transport matériel",
-        base.plusDays(2).toInstant(),
-        base.plusDays(2).plusHours(1).toInstant(),
-        "RDV à 7h30");
+    for (int i = 0; i < 6; i++) {
+      int length = 6 + i;
+      Models.Resource resource =
+          new Models.Resource(
+              UUID.randomUUID().toString(),
+              String.format("Remorque %dm", length),
+              String.format("RE-%02d-%02d", 80 + i, 30 + i),
+              palette[(i + 2) % palette.length],
+              agencyIds.get((i + 2) % agencyIds.size()),
+              String.format("remorque,%dm", length),
+              null);
+      resources.add(resource);
+      resourceTypeAssignments.put(resource.id(), typeRemorque.id());
+      resourceDailyRates.put(resource.id(), 120.0 + i * 20.0);
+    }
 
-    addUnavailability(
-        resources.get(0).id(),
-        "Maintenance",
-        base.plusDays(1).plusHours(6).toInstant(),
-        base.plusDays(1).plusHours(8).toInstant());
-    addUnavailability(
-        resources.get(1).id(),
-        "Panne hydraulique",
-        base.plusDays(1).minusHours(2).toInstant(),
-        base.plusDays(1).minusHours(1).toInstant());
+    for (int i = 0; i < 6; i++) {
+      int height = 10 + 2 * i;
+      Models.Resource resource =
+          new Models.Resource(
+              UUID.randomUUID().toString(),
+              String.format("Nacelle %dm", height),
+              String.format("NA-%02d-%02d", 90 + i, 40 + i),
+              palette[(i + 3) % palette.length],
+              agencyIds.get((i + 3) % agencyIds.size()),
+              String.format("nacelle,%dm", height),
+              null);
+      resources.add(resource);
+      resourceTypeAssignments.put(resource.id(), typeNacelle.id());
+      resourceDailyRates.put(resource.id(), 180.0 + i * 25.0);
+    }
 
-    recurring.add(
-        new Models.RecurringUnavailability(
-            UUID.randomUUID().toString(),
-            resources.get(0).id(),
-            DayOfWeek.MONDAY,
-            LocalTime.of(8, 0),
-            LocalTime.of(10, 0),
-            "Routine hebdo"));
+    for (int i = 0; i < 6; i++) {
+      Models.Resource resource =
+          new Models.Resource(
+              UUID.randomUUID().toString(),
+              String.format("Chauffeur %s", (char) ('A' + i)),
+              null,
+              palette[(i + 4) % palette.length],
+              agencyIds.get((i + 4) % agencyIds.size()),
+              "chauffeur",
+              null);
+      resources.add(resource);
+      resourceTypeAssignments.put(resource.id(), typeChauffeur.id());
+      resourceDailyRates.put(resource.id(), 250.0 + i * 15.0);
+    }
+
+    OffsetDateTime startRef =
+        LocalDate.now()
+            .atTime(9, 0)
+            .atZone(ZoneId.systemDefault())
+            .toOffsetDateTime();
+    String clientAlpha = clients.isEmpty() ? null : clients.get(0).id();
+    String clientBeta = clients.size() > 1 ? clients.get(1).id() : clientAlpha;
+    String driverA = drivers.isEmpty() ? null : drivers.get(0).id();
+    String driverB = drivers.size() > 1 ? drivers.get(1).id() : driverA;
+
+    if (!resources.isEmpty() && clientAlpha != null) {
+      String resA = resources.get(0).id();
+      String resB = resources.size() > 7 ? resources.get(7).id() : resA;
+      String resC = resources.size() > 13 ? resources.get(13).id() : resB;
+
+      interventions.add(
+          new Models.Intervention(
+              UUID.randomUUID().toString(),
+              a1.id(),
+              List.of(resA),
+              clientAlpha,
+              driverA,
+              "Assemblage",
+              startRef.toInstant(),
+              startRef.plusHours(2).toInstant(),
+              "Site A – prévoir EPI"));
+
+      if (clientBeta != null) {
+        interventions.add(
+            new Models.Intervention(
+                UUID.randomUUID().toString(),
+                a1.id(),
+                List.of(resB),
+                clientBeta,
+                driverB,
+                "Livraison",
+                startRef.plusHours(1).toInstant(),
+                startRef.plusHours(4).toInstant(),
+                "Livraison chantier"));
+      }
+
+      List<String> comboResources =
+          resC != null && !resC.equals(resA) ? List.of(resA, resC) : List.of(resA);
+      interventions.add(
+          new Models.Intervention(
+              UUID.randomUUID().toString(),
+              a1.id(),
+              comboResources,
+              clientAlpha,
+              driverA,
+              "Opération combinée",
+              startRef.plusHours(1).toInstant(),
+              startRef.plusHours(3).toInstant(),
+              "Chevauchement volontaire"));
+    }
+
+    if (!resources.isEmpty()) {
+      recurring.add(
+          new Models.RecurringUnavailability(
+              UUID.randomUUID().toString(),
+              resources.get(0).id(),
+              DayOfWeek.MONDAY,
+              LocalTime.of(12, 0),
+              LocalTime.of(14, 0),
+              "Maintenance hebdomadaire"));
+    }
 
     List<Models.DocLine> quoteLines = List.of(new Models.DocLine("Heures grue", 2.0, 120.0, 20.0));
     java.time.OffsetDateTime quoteDate = java.time.OffsetDateTime.now().minusDays(5);
@@ -404,19 +471,7 @@ public class MockDataSource implements DataSourceProvider {
 
   @Override
   public Models.Intervention createIntervention(Models.Intervention intervention) {
-    boolean overlap =
-        interventions.stream()
-            .anyMatch(
-                i ->
-                    conflicts(
-                        i,
-                        intervention.resourceIds(),
-                        intervention.driverId(),
-                        intervention.start(),
-                        intervention.end()));
-    if (overlap) {
-      throw new IllegalStateException("Conflit d'affectation (MOCK)");
-    }
+    // Les conflits d'affectation ne sont plus bloquants côté mock : ils sont indiqués visuellement
     boolean unavailable =
         intervention.resourceIds().stream()
             .anyMatch(
@@ -450,20 +505,7 @@ public class MockDataSource implements DataSourceProvider {
 
   @Override
   public Models.Intervention updateIntervention(Models.Intervention intervention) {
-    boolean overlap =
-        interventions.stream()
-            .filter(i -> !i.id().equals(intervention.id()))
-            .anyMatch(
-                i ->
-                    conflicts(
-                        i,
-                        intervention.resourceIds(),
-                        intervention.driverId(),
-                        intervention.start(),
-                        intervention.end()));
-    if (overlap) {
-      throw new IllegalStateException("Conflit (MOCK) avec une autre intervention");
-    }
+    // Les chevauchements sont acceptés : les avertissements sont gérés dans l'interface
     boolean unavailable =
         intervention.resourceIds().stream()
             .anyMatch(

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -2,6 +2,7 @@ package com.location.client.ui;
 
 import com.location.client.core.DataSourceProvider;
 import com.location.client.core.Models;
+import com.location.client.ui.icons.SvgIconLoader;
 import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -38,10 +39,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.swing.AbstractAction;
 import javax.swing.DefaultListCellRenderer;
+import javax.swing.Icon;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -85,6 +88,7 @@ public class PlanningPanel extends JPanel {
   private static final int SLOT_MINUTES = 15;
   private static final DayOfWeek WEEK_START = DayOfWeek.MONDAY;
   private static final Duration DEFAULT_CREATE_DURATION = Duration.ofHours(2);
+  private static final Icon CONFLICT_ICON = SvgIconLoader.load("conflict.svg", 16);
 
   private int colWidth;
   private Tile dragTile;
@@ -995,6 +999,19 @@ public class PlanningPanel extends JPanel {
     g2.drawRoundRect(x, y, w, height, 10, 10);
     g2.setComposite(AlphaComposite.SrcOver);
 
+    if (conflict) {
+      Icon warn = CONFLICT_ICON;
+      if (warn != null) {
+        int iconWidth = warn.getIconWidth();
+        int iconX = Math.max(x + 4, x + w - iconWidth - 6);
+        int iconY = y + 4;
+        warn.paintIcon(this, g2, iconX, iconY);
+      } else {
+        g2.setColor(new Color(219, 68, 55, 220));
+        g2.fillOval(x + w - 14, y + 6, 10, 10);
+      }
+    }
+
     g2.setColor(new Color(255, 255, 255, 160));
     g2.fillRect(x, y, 4, height);
     g2.fillRect(x + w - 4, y, 4, height);
@@ -1026,12 +1043,26 @@ public class PlanningPanel extends JPanel {
   }
 
   private boolean hasConflict(Tile t) {
+    if (resources.isEmpty()) {
+      return false;
+    }
+    int rowIndex = Math.max(0, Math.min(resources.size() - 1, t.row));
+    String resourceId = resources.get(rowIndex).id();
+    if (resourceId == null) {
+      return false;
+    }
     Instant s = instantForX(Math.min(t.x1, t.x2));
     Instant e = instantForX(Math.max(t.x1, t.x2));
-    String rId = resources.get(Math.max(0, Math.min(resources.size() - 1, t.row))).id();
-    for (Models.Intervention i : interventions) {
-      if (!i.resourceId().equals(rId) || i == t.i) continue;
-      if (i.end().isAfter(s) && i.start().isBefore(e)) return true;
+    for (Models.Intervention intervention : interventions) {
+      if (Objects.equals(intervention.id(), t.i.id())) {
+        continue;
+      }
+      if (!intervention.resourceIds().contains(resourceId)) {
+        continue;
+      }
+      if (intervention.end().isAfter(s) && intervention.start().isBefore(e)) {
+        return true;
+      }
     }
     return false;
   }

--- a/client/src/main/java/com/location/client/ui/icons/SvgIconLoader.java
+++ b/client/src/main/java/com/location/client/ui/icons/SvgIconLoader.java
@@ -77,6 +77,15 @@ public final class SvgIconLoader {
   }
 
   private static List<String> defaultIcons() {
-    return List.of("crane.svg", "truck.svg", "trailer.svg", "forklift.svg", "excavator.svg", "hook.svg");
+    return List.of(
+        "crane.svg",
+        "truck.svg",
+        "trailer.svg",
+        "forklift.svg",
+        "excavator.svg",
+        "hook.svg",
+        "driver.svg",
+        "nacelle.svg",
+        "conflict.svg");
   }
 }

--- a/client/src/main/resources/icons/conflict.svg
+++ b/client/src/main/resources/icons/conflict.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <path d="M32 6 L58 54 H6 Z" fill="#ef5350"/>
+  <rect x="30" y="24" width="4" height="18" fill="#fff"/>
+  <rect x="30" y="46" width="4" height="4" fill="#fff"/>
+</svg>

--- a/client/src/main/resources/icons/driver.svg
+++ b/client/src/main/resources/icons/driver.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <circle cx="32" cy="20" r="10" fill="#90caf9"/>
+  <rect x="18" y="34" width="28" height="16" rx="8" fill="#42a5f5"/>
+</svg>

--- a/client/src/main/resources/icons/icons.txt
+++ b/client/src/main/resources/icons/icons.txt
@@ -4,3 +4,6 @@ trailer.svg
 forklift.svg
 excavator.svg
 hook.svg
+driver.svg
+nacelle.svg
+conflict.svg

--- a/client/src/main/resources/icons/nacelle.svg
+++ b/client/src/main/resources/icons/nacelle.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="none"/>
+  <rect x="10" y="36" width="24" height="6" fill="#90a4ae"/>
+  <rect x="34" y="22" width="4" height="20" fill="#78909c"/>
+  <rect x="38" y="18" width="16" height="8" fill="#b0bec5"/>
+  <circle cx="18" cy="48" r="4" fill="#333"/>
+  <circle cx="30" cy="48" r="4" fill="#333"/>
+</svg>

--- a/server/src/main/java/com/location/server/service/InterventionService.java
+++ b/server/src/main/java/com/location/server/service/InterventionService.java
@@ -53,10 +53,6 @@ public class InterventionService {
     if (!start.isBefore(end)) {
       throw new IllegalArgumentException("start must be before end");
     }
-    if (interventionRepository.existsOverlap(resourceId, start, end)) {
-      throw new AssignmentConflictException(
-          "Intervention en conflit pour la ressource " + resourceId);
-    }
     if (driverId != null
         && !driverId.isBlank()
         && interventionRepository.existsDriverOverlap(driverId, start, end)) {
@@ -90,10 +86,6 @@ public class InterventionService {
       String notes) {
     if (!start.isBefore(end)) {
       throw new IllegalArgumentException("start must be before end");
-    }
-    if (interventionRepository.existsOverlapExcluding(id, resourceId, start, end)) {
-      throw new AssignmentConflictException(
-          "Intervention en conflit pour la ressource " + resourceId);
     }
     if (driverId != null
         && !driverId.isBlank()


### PR DESCRIPTION
## Summary
- allow overlapping resource assignments by removing resource-level conflict checks in the mock datasource and service layer while leaving driver/unavailability validations intact
- enrich the mock dataset with additional resource types, 30 demo resources, and sample interventions plus icons for new asset types and conflicts
- surface resource conflicts visually in the planning panel with a conflict icon and updated SVG loader defaults

## Testing
- mvn -pl client,server -am -DskipTests package *(fails: Maven cannot download dependencies in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da5a694e4c83308ce8664c8cf505bd