### PR TITLE
Add conflict filtering controls and inspector to planning UI

### DIFF
--- a/client/src/main/java/com/location/client/ui/ConflictInspectorFrame.java
+++ b/client/src/main/java/com/location/client/ui/ConflictInspectorFrame.java
@@ -1,0 +1,98 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import com.location.client.core.Models;
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JToolBar;
+import javax.swing.table.DefaultTableModel;
+
+public class ConflictInspectorFrame extends JFrame {
+  private final DataSourceProvider dsp;
+  private final PlanningPanel planning;
+  private final DefaultTableModel model =
+      new DefaultTableModel(new Object[] {"Début", "Fin", "Ressource", "Intervention A", "Intervention B"}, 0) {
+        @Override
+        public boolean isCellEditable(int row, int column) {
+          return false;
+        }
+      };
+  private final JTable table = new JTable(model);
+  private final DateTimeFormatter formatter =
+      DateTimeFormatter.ofPattern("dd/MM HH:mm").withZone(ZoneId.systemDefault());
+  private List<ConflictUtil.Conflict> conflicts = List.of();
+
+  public ConflictInspectorFrame(DataSourceProvider dsp, PlanningPanel planning) {
+    super("Alerte conflits");
+    this.dsp = dsp;
+    this.planning = planning;
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setLayout(new BorderLayout(8, 8));
+
+    table.setRowHeight(24);
+    add(new JScrollPane(table), BorderLayout.CENTER);
+
+    JToolBar toolbar = new JToolBar();
+    toolbar.setFloatable(false);
+    toolbar.add(new JButton(new AbstractAction("Rafraîchir") {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        refresh();
+      }
+    }));
+    toolbar.add(new JButton(new AbstractAction("Afficher dans le planning") {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        goToSelected();
+      }
+    }));
+    add(toolbar, BorderLayout.NORTH);
+
+    setSize(900, 500);
+    setLocationRelativeTo(null);
+    refresh();
+  }
+
+  private void refresh() {
+    conflicts = planning.getConflicts();
+    model.setRowCount(0);
+    List<Models.Resource> resources = dsp.listResources();
+    for (ConflictUtil.Conflict conflict : conflicts) {
+      String resourceId = conflict.resourceId();
+      Models.Resource resource =
+          resources.stream()
+              .filter(r -> resourceId != null && resourceId.equals(r.id()))
+              .findFirst()
+              .orElse(null);
+      model.addRow(
+          new Object[] {
+            formatter.format(conflict.a().start()),
+            formatter.format(conflict.a().end()),
+            resource == null ? resourceId : resource.name(),
+            conflict.a().title(),
+            conflict.b().title()
+          });
+    }
+  }
+
+  private void goToSelected() {
+    int row = table.getSelectedRow();
+    if (row < 0 || row >= conflicts.size()) {
+      return;
+    }
+    ConflictUtil.Conflict conflict = conflicts.get(row);
+    if (conflict.a() != null && conflict.a().start() != null) {
+      planning.setDay(conflict.a().start().atZone(ZoneId.systemDefault()).toLocalDate());
+    }
+    planning.requestFocusInWindow();
+    planning.repaint();
+  }
+}

--- a/client/src/main/java/com/location/client/ui/ConflictUtil.java
+++ b/client/src/main/java/com/location/client/ui/ConflictUtil.java
@@ -1,0 +1,52 @@
+package com.location.client.ui;
+
+import com.location.client.core.Models;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ConflictUtil {
+  private ConflictUtil() {}
+
+  public record Conflict(Models.Intervention a, Models.Intervention b, String resourceId) {}
+
+  public static List<Conflict> computeConflicts(List<Models.Intervention> interventions) {
+    List<Conflict> out = new ArrayList<>();
+    if (interventions == null || interventions.isEmpty()) {
+      return out;
+    }
+    for (int i = 0; i < interventions.size(); i++) {
+      Models.Intervention first = interventions.get(i);
+      for (int j = i + 1; j < interventions.size(); j++) {
+        Models.Intervention second = interventions.get(j);
+        if (!overlap(first.start(), first.end(), second.start(), second.end())) {
+          continue;
+        }
+        String resourceId = firstCommonResource(first, second);
+        if (resourceId != null) {
+          out.add(new Conflict(first, second, resourceId));
+        }
+      }
+    }
+    return out;
+  }
+
+  private static boolean overlap(Instant startA, Instant endA, Instant startB, Instant endB) {
+    if (startA == null || endA == null || startB == null || endB == null) {
+      return false;
+    }
+    return startA.isBefore(endB) && endA.isAfter(startB);
+  }
+
+  private static String firstCommonResource(Models.Intervention a, Models.Intervention b) {
+    if (a.resourceIds() == null || b.resourceIds() == null) {
+      return null;
+    }
+    for (String resourceId : a.resourceIds()) {
+      if (resourceId != null && b.resourceIds().contains(resourceId)) {
+        return resourceId;
+      }
+    }
+    return null;
+  }
+}

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -739,10 +739,13 @@ public class MainFrame extends JFrame {
     generateData.addActionListener(e -> new StressTestDialog(MainFrame.this, dsp, planning).setVisible(true));
     JMenuItem resourceColors = new JMenuItem("Couleurs des ressources…");
     resourceColors.addActionListener(e -> new ResourceColorDialog(MainFrame.this, dsp, planning).setVisible(true));
+    JMenuItem conflictInspector = new JMenuItem("Alerte conflits…");
+    conflictInspector.addActionListener(e -> new ConflictInspectorFrame(dsp, planning).setVisible(true));
     tools.add(newIntervention);
     tools.addSeparator();
     tools.add(generateData);
     tools.add(resourceColors);
+    tools.add(conflictInspector);
 
     JMenu help = new JMenu(Language.tr("menu.help"));
     help.setMnemonic(Language.isEnglish() ? 'H' : 'A');

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.swing.AbstractAction;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JComboBox;
@@ -62,6 +63,7 @@ public class PlanningPanel extends JPanel {
   private List<Models.Client> clients = List.of();
   private List<Models.Intervention> interventions = List.of();
   private List<Models.Unavailability> unavailabilities = List.of();
+  private List<ConflictUtil.Conflict> conflicts = List.of();
   private final List<Runnable> reloadListeners = new ArrayList<>();
   private final java.util.Map<String, Color> resourceColors = new HashMap<>();
   public interface SelectionListener {
@@ -76,6 +78,7 @@ public class PlanningPanel extends JPanel {
   private String filterClientId;
   private String filterQuery = "";
   private String filterTags = "";
+  private boolean filterNoConflicts;
 
   private static final int HEADER_H = 28;
   private static final int ROW_H = 60;
@@ -418,6 +421,20 @@ public class PlanningPanel extends JPanel {
       Set<String> visibleIds = resources.stream().map(Models.Resource::id).collect(Collectors.toSet());
       data = data.stream().filter(i -> visibleIds.contains(i.resourceId())).toList();
     }
+    List<ConflictUtil.Conflict> computedConflicts = ConflictUtil.computeConflicts(data);
+    if (filterNoConflicts && !computedConflicts.isEmpty()) {
+      Set<String> conflictIds =
+          computedConflicts.stream()
+              .flatMap(c -> Stream.of(c.a().id(), c.b().id()))
+              .filter(id -> id != null && !id.isBlank())
+              .collect(Collectors.toSet());
+      data =
+          data.stream()
+              .filter(i -> i.id() == null || !conflictIds.contains(i.id()))
+              .toList();
+      computedConflicts = ConflictUtil.computeConflicts(data);
+    }
+    conflicts = computedConflicts;
     interventions = data;
     if (selectedId != null) {
       selected =
@@ -552,6 +569,15 @@ public class PlanningPanel extends JPanel {
     repaint();
   }
 
+  public void setFilterNoConflicts(boolean value) {
+    if (filterNoConflicts == value) {
+      return;
+    }
+    filterNoConflicts = value;
+    reload();
+    repaint();
+  }
+
   public String getFilterAgencyId() {
     return filterAgencyId;
   }
@@ -570,6 +596,10 @@ public class PlanningPanel extends JPanel {
 
   public String getFilterTags() {
     return filterTags;
+  }
+
+  public boolean isFilterNoConflicts() {
+    return filterNoConflicts;
   }
 
   public List<Models.Resource> getResources() {
@@ -595,6 +625,10 @@ public class PlanningPanel extends JPanel {
 
   public List<Models.Unavailability> getUnavailabilities() {
     return unavailabilities;
+  }
+
+  public List<ConflictUtil.Conflict> getConflicts() {
+    return List.copyOf(conflicts);
   }
 
   public Models.Intervention getSelected() {
@@ -1026,6 +1060,17 @@ public class PlanningPanel extends JPanel {
   }
 
   private boolean hasConflict(Tile t) {
+    if (!conflicts.isEmpty() && t != null && t.i != null && t.i.id() != null) {
+      String id = t.i.id();
+      String resourceId = t.i.resourceId();
+      for (ConflictUtil.Conflict conflict : conflicts) {
+        if ((id.equals(conflict.a().id()) || id.equals(conflict.b().id()))
+            && (conflict.resourceId() == null
+                || conflict.resourceId().equals(resourceId))) {
+          return true;
+        }
+      }
+    }
     Instant s = instantForX(Math.min(t.x1, t.x2));
     Instant e = instantForX(Math.max(t.x1, t.x2));
     String rId = resources.get(Math.max(0, Math.min(resources.size() - 1, t.row))).id();

--- a/client/src/main/java/com/location/client/ui/TopBar.java
+++ b/client/src/main/java/com/location/client/ui/TopBar.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.function.Function;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -30,6 +31,7 @@ public class TopBar extends JPanel {
   private final JComboBox<Models.Client> cbClient = new JComboBox<>();
   private final JTextField tfQuery = new JTextField();
   private final JTextField tfTags = new JTextField();
+  private final JCheckBox cbNoConflicts = new JCheckBox("Sans conflit");
   private final JSpinner spDate = new JSpinner(new SpinnerDateModel());
   private boolean updating = false;
 
@@ -129,6 +131,15 @@ public class TopBar extends JPanel {
           preferences.save();
         });
 
+    cbNoConflicts.setFocusable(false);
+    cbNoConflicts.addActionListener(
+        e -> {
+          if (updating) {
+            return;
+          }
+          planning.setFilterNoConflicts(cbNoConflicts.isSelected());
+        });
+
     right.add(new JLabel("Agence:"));
     right.add(cbAgency);
     right.add(new JLabel("Ressource:"));
@@ -139,6 +150,7 @@ public class TopBar extends JPanel {
     right.add(tfQuery);
     right.add(new JLabel("Tags:"));
     right.add(tfTags);
+    right.add(cbNoConflicts);
 
     add(left, BorderLayout.WEST);
     add(right, BorderLayout.EAST);
@@ -155,6 +167,12 @@ public class TopBar extends JPanel {
     String savedTags = preferences.getFilterTags();
     tfTags.setText(savedTags);
     planning.setFilterTags(savedTags);
+    updating = true;
+    try {
+      cbNoConflicts.setSelected(planning.isFilterNoConflicts());
+    } finally {
+      updating = false;
+    }
     refreshCombos();
     selectById(cbAgency, Models.Agency::id, preferences.getFilterAgencyId());
     selectById(cbResource, Models.Resource::id, preferences.getFilterResourceId());


### PR DESCRIPTION
## Summary
- add an optional "no conflicts" filter to the planning view and surface the current conflicts
- introduce a reusable conflict detection helper and a dedicated inspector window
- surface the new filter toggle on the top bar and expose the inspector from the tools menu

## Testing
- mvn -pl client -am -DskipTests compile *(fails: unable to download org.springframework.boot:spring-boot-dependencies due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da5c2c7c9c8330a3e124ed27e4f1b1