### PR TITLE
Improve intervention flows and conflict handling

### DIFF
--- a/client/src/main/java/com/location/client/ui/InterventionEditorDialog.java
+++ b/client/src/main/java/com/location/client/ui/InterventionEditorDialog.java
@@ -60,7 +60,7 @@ public class InterventionEditorDialog extends JDialog {
             : new Models.Intervention(
                 null,
                 null,
-                null,
+                List.of(),
                 null,
                 null,
                 "Nouvelle intervention",

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -1363,8 +1363,9 @@ public class MainFrame extends JFrame {
       toast("Ressources/Clients vides");
       return;
     }
-    Models.Resource defaultResource = resources.get(0);
-    Models.Client defaultClient = clients.get(0);
+    JComboBox<Models.Resource> cbR = new JComboBox<>(resources.toArray(new Models.Resource[0]));
+    JComboBox<Models.Client> cbC = new JComboBox<>(clients.toArray(new Models.Client[0]));
+    JTextField tfTitle = new JTextField("Nouvelle intervention", 24);
     Instant start = Instant.now().plus(Duration.ofHours(1));
     JTextField tfStart = new JTextField(start.toString());
     JTextField tfEnd = new JTextField(start.plus(Duration.ofHours(2)).toString());
@@ -1404,9 +1405,9 @@ public class MainFrame extends JFrame {
                     resource.id(),
                     client.id(),
                     null,
-                    tfTitle.getText(),
-                    Instant.parse(tfStart.getText()),
-                    Instant.parse(tfEnd.getText()),
+                    tfTitle.getText().trim(),
+                    Instant.parse(tfStart.getText().trim()),
+                    Instant.parse(tfEnd.getText().trim()),
                     null,
                     price));
         toastSuccess("Intervention créée");

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -1081,21 +1081,29 @@ public class PlanningPanel extends JPanel {
   }
 
   private boolean hasConflict(Tile t) {
-    if (!conflicts.isEmpty() && t != null && t.i != null && t.i.id() != null) {
-      String id = t.i.id();
-      String resourceId = t.i.resourceId();
+    if (t == null || t.i == null) {
+      return false;
+    }
+    String resourceId = t.i.resourceId();
+    String id = t.i.id();
+    if (!conflicts.isEmpty() && id != null) {
       for (ConflictUtil.Conflict conflict : conflicts) {
-        if ((id.equals(conflict.a().id()) || id.equals(conflict.b().id()))
-            && (conflict.resourceId() == null
-                || conflict.resourceId().equals(resourceId))) {
+        boolean sameIntervention =
+            id.equals(conflict.a().id()) || id.equals(conflict.b().id());
+        boolean sameResource =
+            conflict.resourceId() == null || Objects.equals(conflict.resourceId(), resourceId);
+        if (sameIntervention && sameResource) {
           return true;
         }
       }
     }
+    if (resourceId == null) {
+      return false;
+    }
     Instant s = instantForX(Math.min(t.x1, t.x2));
     Instant e = instantForX(Math.max(t.x1, t.x2));
     for (Models.Intervention intervention : interventions) {
-      if (Objects.equals(intervention.id(), t.i.id())) {
+      if (Objects.equals(intervention.id(), id)) {
         continue;
       }
       if (!intervention.resourceIds().contains(resourceId)) {

--- a/client/src/main/java/com/location/client/ui/ResourceExplorerFrame.java
+++ b/client/src/main/java/com/location/client/ui/ResourceExplorerFrame.java
@@ -43,6 +43,7 @@ import javax.swing.JToolBar;
 import javax.swing.ListCellRenderer;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
 
 public class ResourceExplorerFrame extends JFrame {
@@ -239,7 +240,9 @@ public class ResourceExplorerFrame extends JFrame {
       try {
         dataSourceProvider.setResourceTypeForResource(saved.id(), chosenType.id());
       } catch (UnsupportedOperationException ex) {
-        Toast.error(this, "Attribution de type indisponible: " + ex.getMessage());
+        Toast.error(
+            SwingUtilities.getWindowAncestor(this),
+            "Attribution de type indisponible: " + ex.getMessage());
         typeSupport = false;
       }
     }
@@ -277,7 +280,7 @@ public class ResourceExplorerFrame extends JFrame {
 
   private void onResourceUpdated(Models.Resource updated) {
     buildAccordion();
-    Toast.success(this, "Ressource mise à jour");
+    Toast.success(SwingUtilities.getWindowAncestor(this), "Ressource mise à jour");
     showDetails(updated);
   }
 
@@ -538,7 +541,7 @@ public class ResourceExplorerFrame extends JFrame {
         dataSourceProvider.saveUnavailability(
             new Models.Unavailability(null, resource.id(), reason, startInstant, endInstant, false));
         loadUnavailabilities();
-        Toast.success(this, "Indisponibilité ajoutée");
+        Toast.success(SwingUtilities.getWindowAncestor(this), "Indisponibilité ajoutée");
       } catch (RuntimeException ex) {
         JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
       }
@@ -558,7 +561,7 @@ public class ResourceExplorerFrame extends JFrame {
       try {
         dataSourceProvider.deleteUnavailability(selected.id());
         loadUnavailabilities();
-        Toast.info(this, "Indisponibilité supprimée");
+        Toast.info(SwingUtilities.getWindowAncestor(this), "Indisponibilité supprimée");
       } catch (RuntimeException ex) {
         JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
       }


### PR DESCRIPTION
## Summary
- ensure the intervention editor builds a new record with an empty resource list
- refresh the quick-create dialog with combo boxes, trimmed input, and price parsing
- harden planning conflict detection when no resource is selected and reuse the detected id
- show resource explorer toasts on the owning window to avoid context issues

## Testing
- mvn -pl client -am -DskipTests compile *(fails: Maven Central returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da68c430748330b1ce125b561924d0