### PR TITLE
Display document counts in navigation badges

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -1009,8 +1009,22 @@ public class MainFrame extends JFrame {
             e -> {
               sidebar.setBadge("planning", planning.conflictCount());
               try {
-                List<Models.Doc> docs = dsp.listDocs("QUOTE", null);
-                sidebar.setBadge("docs", docs == null ? 0 : docs.size());
+                List<Models.Doc> docs = dsp.listDocs(null, null);
+                if (docs == null || docs.isEmpty()) {
+                  sidebar.setBadgeText("docs", null);
+                } else {
+                  long quotes = docs.stream().filter(d -> "QUOTE".equals(d.type())).count();
+                  long orders = docs.stream().filter(d -> "ORDER".equals(d.type())).count();
+                  long deliveries =
+                      docs.stream().filter(d -> "DELIVERY".equals(d.type())).count();
+                  long invoices = docs.stream().filter(d -> "INVOICE".equals(d.type())).count();
+                  String text =
+                      "Q" + quotes +
+                      " BC" + orders +
+                      " BL" + deliveries +
+                      " F" + invoices;
+                  sidebar.setBadgeText("docs", text);
+                }
               } catch (Exception ignored) {
               }
             });

--- a/client/src/main/java/com/location/client/ui/Sidebar.java
+++ b/client/src/main/java/com/location/client/ui/Sidebar.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -66,6 +67,13 @@ public class Sidebar extends JPanel {
     }
   }
 
+  public void setBadgeText(String id, String text) {
+    IconBadgeButton button = items.get(id);
+    if (button != null) {
+      button.setBadgeText(text);
+    }
+  }
+
   public int indexOf(String id) {
     for (int i = 0; i < entries.size(); i++) {
       if (entries.get(i).id().equals(id)) {
@@ -88,6 +96,7 @@ public class Sidebar extends JPanel {
 
   private static class IconBadgeButton extends JButton {
     private int badgeCount;
+    private String badgeText;
 
     IconBadgeButton(String text, Icon icon) {
       super(text, icon);
@@ -99,8 +108,17 @@ public class Sidebar extends JPanel {
     }
 
     void setBadgeCount(int badgeCount) {
-      if (this.badgeCount != badgeCount) {
+      if (this.badgeCount != badgeCount || badgeText != null) {
         this.badgeCount = badgeCount;
+        this.badgeText = null;
+        repaint();
+      }
+    }
+
+    void setBadgeText(String badgeText) {
+      String normalized = badgeText != null && !badgeText.isBlank() ? badgeText : null;
+      if (!Objects.equals(this.badgeText, normalized)) {
+        this.badgeText = normalized;
         repaint();
       }
     }
@@ -108,22 +126,25 @@ public class Sidebar extends JPanel {
     @Override
     protected void paintComponent(Graphics g) {
       super.paintComponent(g);
-      if (badgeCount <= 0) {
+      String text = badgeText != null ? badgeText : (badgeCount > 0 ? String.valueOf(badgeCount) : null);
+      if (text == null) {
         return;
       }
       Graphics2D g2 = (Graphics2D) g.create();
       g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-      int radius = 16;
-      int x = getWidth() - radius - 8;
+      g2.setFont(g2.getFont().deriveFont(java.awt.Font.BOLD, 11f));
+      java.awt.FontMetrics fm = g2.getFontMetrics();
+      int paddingX = 8;
+      int paddingY = 4;
+      int width = fm.stringWidth(text) + paddingX * 2;
+      int height = fm.getHeight() + paddingY;
+      int x = getWidth() - width - 8;
       int y = 6;
       g2.setColor(new Color(220, 30, 35));
-      g2.fillOval(x, y, radius, radius);
+      g2.fillRoundRect(x, y, width, height, height, height);
       g2.setColor(Color.WHITE);
-      g2.setFont(g2.getFont().deriveFont(java.awt.Font.BOLD, 11f));
-      String text = String.valueOf(badgeCount);
-      java.awt.FontMetrics fm = g2.getFontMetrics();
-      int textX = x + (radius - fm.stringWidth(text)) / 2;
-      int textY = y + (radius + fm.getAscent() - fm.getDescent()) / 2 - 1;
+      int textX = x + (width - fm.stringWidth(text)) / 2;
+      int textY = y + (height + fm.getAscent() - fm.getDescent()) / 2 - 1;
       g2.drawString(text, textX, textY);
       g2.dispose();
     }


### PR DESCRIPTION
## Summary
- allow sidebar navigation badges to render custom text in addition to numeric counts
- show document totals per type inside the quick document browser window
- aggregate document counts in the main window and surface them on the Documents badge

## Testing
- mvn -pl client -am -DskipTests compile *(fails: unable to download org.springframework.boot:spring-boot-dependencies:pom:3.3.2 because Maven Central returned HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da767afb4c8330989b30bd22ec041a