### PR TITLE
Add internal notes to interventions

### DIFF
--- a/client/src/main/java/com/location/client/core/MockDataSource.java
+++ b/client/src/main/java/com/location/client/core/MockDataSource.java
@@ -695,6 +695,7 @@ public class MockDataSource implements DataSourceProvider {
             intervention.start(),
             intervention.end(),
             intervention.notes(),
+            intervention.internalNotes(),
             intervention.price());
     interventions.add(created);
     return created;
@@ -1324,6 +1325,7 @@ public class MockDataSource implements DataSourceProvider {
             start,
             end,
             notes,
+            null,
             price));
   }
 

--- a/client/src/main/java/com/location/client/core/Models.java
+++ b/client/src/main/java/com/location/client/core/Models.java
@@ -57,6 +57,7 @@ public final class Models {
       Instant start,
       Instant end,
       String notes,
+      String internalNotes,
       Double price) {
     public Intervention {
       resourceIds = resourceIds == null ? List.of() : List.copyOf(resourceIds);
@@ -72,7 +73,7 @@ public final class Models {
         Instant start,
         Instant end,
         String notes) {
-      this(id, agencyId, resourceId, clientId, driverId, title, start, end, notes, null);
+      this(id, agencyId, resourceId, clientId, driverId, title, start, end, notes, null, null);
     }
 
     public Intervention(
@@ -85,7 +86,7 @@ public final class Models {
         Instant start,
         Instant end,
         String notes) {
-      this(id, agencyId, resourceIds, clientId, driverId, title, start, end, notes, null);
+      this(id, agencyId, resourceIds, clientId, driverId, title, start, end, notes, null, null);
     }
 
     public Intervention(
@@ -98,6 +99,7 @@ public final class Models {
         Instant start,
         Instant end,
         String notes,
+        String internalNotes,
         Double price) {
       this(
           id,
@@ -109,6 +111,7 @@ public final class Models {
           start,
           end,
           notes,
+          internalNotes,
           price);
     }
 
@@ -127,6 +130,7 @@ public final class Models {
           start,
           end,
           notes,
+          internalNotes,
           price);
     }
   }

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -721,10 +721,26 @@ public class RestDataSource implements DataSourceProvider {
           java.time.Instant end = java.time.Instant.parse(intervention.path("end").asText());
           JsonNode notesNode = intervention.path("notes");
           String notes = notesNode.isMissingNode() || notesNode.isNull() ? null : notesNode.asText();
+          JsonNode internalNotesNode = intervention.path("internalNotes");
+          String internalNotes =
+              internalNotesNode.isMissingNode() || internalNotesNode.isNull()
+                  ? null
+                  : internalNotesNode.asText();
           JsonNode priceNode = intervention.path("price");
           Double price = priceNode.isMissingNode() || priceNode.isNull() ? null : priceNode.asDouble();
           result.add(
-              new Models.Intervention(id, agency, resources, client, driver, title, start, end, notes, price));
+              new Models.Intervention(
+                  id,
+                  agency,
+                  resources,
+                  client,
+                  driver,
+                  title,
+                  start,
+                  end,
+                  notes,
+                  internalNotes,
+                  price));
         }
       }
       return result;
@@ -774,6 +790,11 @@ public class RestDataSource implements DataSourceProvider {
                 } else {
                   payload.putNull("notes");
                 }
+                if (intervention.internalNotes() != null) {
+                  payload.put("internalNotes", intervention.internalNotes());
+                } else {
+                  payload.putNull("internalNotes");
+                }
                 if (intervention.price() != null) {
                   payload.put("price", intervention.price());
                 } else {
@@ -785,8 +806,14 @@ public class RestDataSource implements DataSourceProvider {
       String id = node.path("id").asText();
       JsonNode notesNode = node.path("notes");
       String notes = notesNode.isMissingNode() || notesNode.isNull() ? null : notesNode.asText();
+      JsonNode internalNotesNode = node.path("internalNotes");
+      String internalNotes =
+          internalNotesNode.isMissingNode() || internalNotesNode.isNull()
+              ? intervention.internalNotes()
+              : internalNotesNode.asText();
       JsonNode priceNode = node.path("price");
-      Double price = priceNode.isMissingNode() || priceNode.isNull() ? intervention.price() : priceNode.asDouble();
+      Double price =
+          priceNode.isMissingNode() || priceNode.isNull() ? intervention.price() : priceNode.asDouble();
       return new Models.Intervention(
           id,
           intervention.agencyId(),
@@ -797,6 +824,7 @@ public class RestDataSource implements DataSourceProvider {
           intervention.start(),
           intervention.end(),
           notes,
+          internalNotes,
           price);
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -846,6 +874,11 @@ public class RestDataSource implements DataSourceProvider {
                 } else {
                   payload.putNull("notes");
                 }
+                if (intervention.internalNotes() != null) {
+                  payload.put("internalNotes", intervention.internalNotes());
+                } else {
+                  payload.putNull("internalNotes");
+                }
                 if (intervention.price() != null) {
                   payload.put("price", intervention.price());
                 } else {
@@ -868,6 +901,9 @@ public class RestDataSource implements DataSourceProvider {
           node.path("notes").isMissingNode() || node.path("notes").isNull()
               ? null
               : node.path("notes").asText(),
+          node.path("internalNotes").isMissingNode() || node.path("internalNotes").isNull()
+              ? null
+              : node.path("internalNotes").asText(),
           node.path("price").isMissingNode() || node.path("price").isNull()
               ? null
               : node.path("price").asDouble());

--- a/client/src/main/java/com/location/client/ui/InterventionEditorDialog.java
+++ b/client/src/main/java/com/location/client/ui/InterventionEditorDialog.java
@@ -44,6 +44,7 @@ public class InterventionEditorDialog extends JDialog {
   private final JComboBox<Models.Client> clientCombo = new JComboBox<>();
   private final JComboBox<Models.Resource> resourceCombo = new JComboBox<>();
   private final JTextArea notesArea = new JTextArea(4, 24);
+  private final JTextArea internalNotesArea = new JTextArea(4, 24);
   private final JSpinner startSpinner = new JSpinner(new SpinnerDateModel());
   private final JSpinner endSpinner = new JSpinner(new SpinnerDateModel());
 
@@ -66,6 +67,8 @@ public class InterventionEditorDialog extends JDialog {
                 "Nouvelle intervention",
                 Instant.now().plus(Duration.ofHours(1)),
                 Instant.now().plus(Duration.ofHours(3)),
+                null,
+                null,
                 null);
 
     setLayout(new BorderLayout());
@@ -118,6 +121,13 @@ public class InterventionEditorDialog extends JDialog {
     form.add(new JLabel("Notes"), c);
     c.gridy++;
     form.add(new JScrollPane(notesArea), c);
+
+    c.gridy++;
+    internalNotesArea.setLineWrap(true);
+    internalNotesArea.setWrapStyleWord(true);
+    form.add(new JLabel("Notes internes"), c);
+    c.gridy++;
+    form.add(new JScrollPane(internalNotesArea), c);
 
     return form;
   }
@@ -213,6 +223,7 @@ public class InterventionEditorDialog extends JDialog {
     titleField.setText(current.title() != null ? current.title() : "");
     driverField.setText(current.driverId() != null ? current.driverId() : "");
     notesArea.setText(current.notes() != null ? current.notes() : "");
+    internalNotesArea.setText(current.internalNotes() != null ? current.internalNotes() : "");
 
     if (current.start() != null) {
       startSpinner.setValue(Date.from(current.start()));
@@ -270,6 +281,10 @@ public class InterventionEditorDialog extends JDialog {
       if (notes != null && notes.isBlank()) {
         notes = null;
       }
+      String internalNotes = internalNotesArea.getText();
+      if (internalNotes != null && internalNotes.isBlank()) {
+        internalNotes = null;
+      }
 
       boolean isCreation = current.id() == null;
       Models.Intervention payload =
@@ -282,7 +297,8 @@ public class InterventionEditorDialog extends JDialog {
               title,
               start,
               end,
-              notes);
+              notes,
+              internalNotes);
 
       Models.Intervention saved =
           isCreation ? dsp.createIntervention(payload) : dsp.updateIntervention(payload);

--- a/server/src/main/java/com/location/server/api/v1/ApiV1Controller.java
+++ b/server/src/main/java/com/location/server/api/v1/ApiV1Controller.java
@@ -346,6 +346,7 @@ public class ApiV1Controller {
             request.start(),
             request.end(),
             request.notes(),
+            request.internalNotes(),
             request.price()));
   }
 
@@ -363,6 +364,7 @@ public class ApiV1Controller {
             request.start(),
             request.end(),
             request.notes(),
+            request.internalNotes(),
             request.price()));
   }
 

--- a/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
+++ b/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
@@ -137,6 +137,7 @@ public final class ApiV1Dtos {
       OffsetDateTime start,
       OffsetDateTime end,
       String notes,
+      String internalNotes,
       Double price) {
     public static InterventionDto of(Intervention intervention) {
       return new InterventionDto(
@@ -149,6 +150,7 @@ public final class ApiV1Dtos {
           intervention.getStart(),
           intervention.getEnd(),
           intervention.getNotes(),
+          intervention.getInternalNotes(),
           intervention.getPrice());
     }
   }
@@ -198,6 +200,7 @@ public final class ApiV1Dtos {
       @NotNull OffsetDateTime start,
       @NotNull OffsetDateTime end,
       @Size(max = 4000) String notes,
+      @Size(max = 4000) String internalNotes,
       @DecimalMin(value = "0.0", inclusive = true) Double price) {}
 
   public record UpdateInterventionRequest(
@@ -209,6 +212,7 @@ public final class ApiV1Dtos {
       @NotNull OffsetDateTime start,
       @NotNull OffsetDateTime end,
       @Size(max = 4000) String notes,
+      @Size(max = 4000) String internalNotes,
       @DecimalMin(value = "0.0", inclusive = true) Double price) {}
 
   public record CreateUnavailabilityRequest(

--- a/server/src/main/java/com/location/server/domain/Intervention.java
+++ b/server/src/main/java/com/location/server/domain/Intervention.java
@@ -49,6 +49,9 @@ public class Intervention {
   @Column(columnDefinition = "TEXT")
   private String notes;
 
+  @Column(name = "internal_notes", length = 4000)
+  private String internalNotes;
+
   @Column(name = "price_eur")
   private Double price;
 
@@ -74,7 +77,7 @@ public class Intervention {
       Resource resource,
       Client client,
       String notes) {
-    this(id, title, start, end, agency, resource, client, null, notes, null);
+    this(id, title, start, end, agency, resource, client, null, notes, null, null);
   }
 
   public Intervention(
@@ -87,6 +90,7 @@ public class Intervention {
       Client client,
       Driver driver,
       String notes,
+      String internalNotes,
       Double price) {
     this.id = id;
     this.title = title;
@@ -97,6 +101,7 @@ public class Intervention {
     this.client = client;
     this.driver = driver;
     this.notes = notes;
+    this.internalNotes = internalNotes;
     this.price = price;
   }
 
@@ -170,6 +175,14 @@ public class Intervention {
 
   public void setNotes(String notes) {
     this.notes = notes;
+  }
+
+  public String getInternalNotes() {
+    return internalNotes;
+  }
+
+  public void setInternalNotes(String internalNotes) {
+    this.internalNotes = internalNotes;
   }
 
   public Double getPrice() {

--- a/server/src/main/java/com/location/server/service/InterventionService.java
+++ b/server/src/main/java/com/location/server/service/InterventionService.java
@@ -50,6 +50,7 @@ public class InterventionService {
       OffsetDateTime start,
       OffsetDateTime end,
       String notes,
+      String internalNotes,
       Double price) {
     if (!start.isBefore(end)) {
       throw new IllegalArgumentException("start must be before end");
@@ -79,6 +80,7 @@ public class InterventionService {
             client,
             driver,
             notes,
+            internalNotes,
             price);
     return interventionRepository.save(intervention);
   }
@@ -94,6 +96,7 @@ public class InterventionService {
       OffsetDateTime start,
       OffsetDateTime end,
       String notes,
+      String internalNotes,
       Double price) {
     if (!start.isBefore(end)) {
       throw new IllegalArgumentException("start must be before end");
@@ -127,6 +130,7 @@ public class InterventionService {
     intervention.setStart(start);
     intervention.setEnd(end);
     intervention.setNotes(notes);
+    intervention.setInternalNotes(internalNotes);
     intervention.setPrice(price);
     return interventionRepository.save(intervention);
   }

--- a/server/src/main/resources/db/migration/V17__intervention_internal_notes.sql
+++ b/server/src/main/resources/db/migration/V17__intervention_internal_notes.sql
@@ -1,0 +1,2 @@
+-- Add internal notes to intervention
+ALTER TABLE intervention ADD COLUMN internal_notes VARCHAR(4000);


### PR DESCRIPTION
## Summary
- add an `internalNotes` column to interventions along with migration and entity accessors
- expose the new field through API DTOs/service methods and REST client models/data source
- surface internal notes in the desktop editor dialog and mock data source

## Testing
- mvn -pl server test *(fails: cannot download dependencies from Maven Central, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68db87f50980833092aa2e5b00ff4c34