### PR TITLE
Enable embedded admin panels and quote creation

### DIFF
--- a/client/src/main/java/com/location/client/ui/ClientsAdminFrame.java
+++ b/client/src/main/java/com/location/client/ui/ClientsAdminFrame.java
@@ -34,6 +34,11 @@ import javax.swing.table.DefaultTableModel;
 
 /** Administration des clients & contacts. */
 public class ClientsAdminFrame extends JFrame {
+  public static JPanel createContent(DataSourceProvider dsp) {
+    ClientsAdminFrame tmp = new ClientsAdminFrame(dsp, true);
+    return (JPanel) tmp.getContentPane();
+  }
+
   private final DataSourceProvider dsp;
 
   private final DefaultTableModel listModel =
@@ -68,6 +73,10 @@ public class ClientsAdminFrame extends JFrame {
   private final List<Models.Contact> contactData = new ArrayList<>();
 
   public ClientsAdminFrame(DataSourceProvider dsp) {
+    this(dsp, false);
+  }
+
+  private ClientsAdminFrame(DataSourceProvider dsp, boolean forEmbedding) {
     super("Clients — Administration");
     this.dsp = dsp;
     setLayout(new BorderLayout(8, 8));
@@ -137,7 +146,9 @@ public class ClientsAdminFrame extends JFrame {
             });
 
     setSize(1000, 620);
-    setLocationRelativeTo(null);
+    if (!forEmbedding) {
+      setLocationRelativeTo(null);
+    }
 
     refreshList();
   }

--- a/client/src/main/java/com/location/client/ui/InterventionEditorDialog.java
+++ b/client/src/main/java/com/location/client/ui/InterventionEditorDialog.java
@@ -134,6 +134,60 @@ public class InterventionEditorDialog extends JDialog {
 
   private JPanel buildButtons() {
     JPanel buttons = new JPanel();
+    JButton quoteButton =
+        new JButton(
+            new AbstractAction("Créer/Modifier le devis") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                Models.Client client = (Models.Client) clientCombo.getSelectedItem();
+                Models.Resource resource = (Models.Resource) resourceCombo.getSelectedItem();
+                if (client == null || resource == null) {
+                  notifyError("Sélectionne client et ressource");
+                  return;
+                }
+                String driver = driverField.getText().trim();
+                if (driver.isBlank()) {
+                  driver = null;
+                }
+                String title = titleField.getText().trim();
+                if (title.isBlank()) {
+                  notifyError("Titre requis");
+                  return;
+                }
+                Date sd = (Date) startSpinner.getValue();
+                Date ed = (Date) endSpinner.getValue();
+                Instant start = sd.toInstant();
+                Instant end = ed.toInstant();
+                String notes = notesArea.getText().trim();
+                if (notes.isBlank()) {
+                  notes = null;
+                }
+                String internalNotes = internalNotesArea.getText().trim();
+                if (internalNotes.isBlank()) {
+                  internalNotes = null;
+                }
+                boolean isCreation = current.id() == null;
+                Models.Intervention payload =
+                    new Models.Intervention(
+                        current.id(),
+                        resource.agencyId(),
+                        resource.id(),
+                        client.id(),
+                        driver,
+                        title,
+                        start,
+                        end,
+                        notes,
+                        internalNotes);
+                Models.Intervention effective = payload;
+                if (isCreation) {
+                  effective = dsp.createIntervention(payload);
+                }
+                current = effective;
+                dsp.createQuoteFromIntervention(effective);
+                notifySuccess("Devis créé/mis à jour");
+              }
+            });
     JButton cancel =
         new JButton(
             new AbstractAction("Annuler") {
@@ -151,6 +205,7 @@ public class InterventionEditorDialog extends JDialog {
               }
             });
     getRootPane().setDefaultButton(save);
+    buttons.add(quoteButton);
     buttons.add(cancel);
     buttons.add(save);
     return buttons;

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -36,6 +36,9 @@ public class MainFrame extends JFrame {
   private final Preferences prefs;
   private final PlanningPanel planning;
   private final PlanningMinimap minimap;
+  private final JPanel centerCards = new JPanel(new java.awt.CardLayout());
+  private JPanel clientsPanel;
+  private JPanel unavPanel;
   private final TopBar topBar;
   private final Sidebar sidebar;
   private final JToolBar selectionBar = new JToolBar();
@@ -124,6 +127,8 @@ public class MainFrame extends JFrame {
     JPanel planningContainer = new JPanel(new BorderLayout());
     planningContainer.add(planning, BorderLayout.CENTER);
     planningContainer.add(minimap, BorderLayout.SOUTH);
+
+    centerCards.add(planningContainer, "planning");
     SuggestionPanel suggestionPanel = new SuggestionPanel(dsp);
     suggestionPanel.setHours(planning.getStartHour(), planning.getEndHour());
     suggestionPanel.setAfterApply(planning::reload);
@@ -183,9 +188,10 @@ public class MainFrame extends JFrame {
           prefs.setDayIso(planning.getDay().toString());
           prefs.save();
         });
-    add(planningContainer, BorderLayout.CENTER);
+    add(centerCards, BorderLayout.CENTER);
     add(suggestionPanel, BorderLayout.EAST);
     sidebar.setSelected("planning");
+    showCard("planning");
     registerNavigationShortcuts();
     startBadgeTimer();
     JPanel south = new JPanel(new BorderLayout());
@@ -953,28 +959,45 @@ public class MainFrame extends JFrame {
 
   private void handleNavigation(String target) {
     switch (target) {
-      case "planning" -> sidebar.setSelected("planning");
+      case "planning" -> {
+        sidebar.setSelected("planning");
+        showCard("planning");
+      }
       case "docs" -> {
         openDocuments();
         sidebar.setSelected("planning");
+        showCard("planning");
       }
       case "clients" -> {
-        new ClientsAdminFrame(dsp).setVisible(true);
-        sidebar.setSelected("planning");
+        if (clientsPanel == null) {
+          clientsPanel = ClientsAdminFrame.createContent(dsp);
+          centerCards.add(clientsPanel, "clients");
+        }
+        sidebar.setSelected("clients");
+        showCard("clients");
       }
       case "resources" -> {
         showPlaceholder("Ressources");
         sidebar.setSelected("planning");
+        showCard("planning");
       }
       case "drivers" -> {
         showPlaceholder("Chauffeurs");
         sidebar.setSelected("planning");
+        showCard("planning");
       }
       case "unav" -> {
-        showPlaceholder("Indisponibilités");
-        sidebar.setSelected("planning");
+        if (unavPanel == null) {
+          unavPanel = UnavailabilityFrame.createContent(dsp);
+          centerCards.add(unavPanel, "unav");
+        }
+        sidebar.setSelected("unav");
+        showCard("unav");
       }
-      default -> sidebar.setSelected("planning");
+      default -> {
+        sidebar.setSelected("planning");
+        showCard("planning");
+      }
     }
   }
 
@@ -1101,6 +1124,11 @@ public class MainFrame extends JFrame {
         feature + " — module en préparation",
         "Navigation",
         JOptionPane.INFORMATION_MESSAGE);
+  }
+
+  private void showCard(String id) {
+    java.awt.CardLayout layout = (java.awt.CardLayout) centerCards.getLayout();
+    layout.show(centerCards, id);
   }
 
   private void exportPlanningDayCsvDialog() {

--- a/client/src/main/java/com/location/client/ui/UnavailabilityFrame.java
+++ b/client/src/main/java/com/location/client/ui/UnavailabilityFrame.java
@@ -26,15 +26,26 @@ import javax.swing.JToolBar;
 import javax.swing.table.DefaultTableModel;
 
 public class UnavailabilityFrame extends JFrame {
+  public static JPanel createContent(DataSourceProvider dsp) {
+    UnavailabilityFrame tmp = new UnavailabilityFrame(dsp, true);
+    return (JPanel) tmp.getContentPane();
+  }
+
   private final DataSourceProvider dataSourceProvider;
   private final JComboBox<Models.Resource> resourceCombo = new JComboBox<>();
   private final DefaultTableModel model;
   private final JTable table;
 
   public UnavailabilityFrame(DataSourceProvider dsp) {
+    this(dsp, false);
+  }
+
+  private UnavailabilityFrame(DataSourceProvider dsp, boolean forEmbedding) {
     super("Indisponibilités ressources");
     this.dataSourceProvider = dsp;
-    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    if (!forEmbedding) {
+      setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    }
     setLayout(new BorderLayout(6, 6));
 
     JPanel top = new JPanel(new FlowLayout(FlowLayout.LEFT));
@@ -90,7 +101,9 @@ public class UnavailabilityFrame extends JFrame {
     add(new JScrollPane(table), BorderLayout.CENTER);
 
     setSize(960, 520);
-    setLocationRelativeTo(null);
+    if (!forEmbedding) {
+      setLocationRelativeTo(null);
+    }
 
     if (resourceCombo.getItemCount() > 0) {
       resourceCombo.setSelectedIndex(0);


### PR DESCRIPTION
## Summary
- embed the clients and unavailability administration views directly in the main frame using a card layout
- adjust the standalone frames so their content can be reused without forcing window behavior when embedded
- add a button in the intervention editor to generate or refresh a quote from the current form values

## Testing
- mvn -pl client test *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.3.2 – HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68db8bdd9ec483309577959afba348dc