### PR TITLE
Add conflict navigation menu and filtering

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -475,8 +475,51 @@ public class MainFrame extends JFrame {
             });
   }
 
+  private JMenu buildConflictsMenu() {
+    JMenu conflicts = new JMenu("Conflits");
+    conflicts.addMenuListener(
+        new javax.swing.event.MenuListener() {
+          @Override
+          public void menuSelected(javax.swing.event.MenuEvent e) {
+            try {
+              int n = planning.getConflicts() == null ? 0 : planning.getConflicts().size();
+              conflicts.setText("Conflits (" + n + ")");
+            } catch (Exception ignored) {
+            }
+          }
+
+          @Override
+          public void menuDeselected(javax.swing.event.MenuEvent e) {}
+
+          @Override
+          public void menuCanceled(javax.swing.event.MenuEvent e) {}
+        });
+    JMenuItem next = new JMenuItem("Aller au prochain conflit");
+    next.setAccelerator(
+        KeyStroke.getKeyStroke(
+            java.awt.event.KeyEvent.VK_RIGHT,
+            java.awt.event.InputEvent.CTRL_DOWN_MASK | java.awt.event.InputEvent.ALT_DOWN_MASK));
+    next.addActionListener(e -> planning.nextConflict());
+    JMenuItem prev = new JMenuItem("Aller au conflit précédent");
+    prev.setAccelerator(
+        KeyStroke.getKeyStroke(
+            java.awt.event.KeyEvent.VK_LEFT,
+            java.awt.event.InputEvent.CTRL_DOWN_MASK | java.awt.event.InputEvent.ALT_DOWN_MASK));
+    prev.addActionListener(e -> planning.prevConflict());
+    JCheckBoxMenuItem only = new JCheckBoxMenuItem("Afficher uniquement les conflits");
+    only.setSelected(planning.isFilterOnlyConflicts());
+    only.addActionListener(e -> planning.setFilterOnlyConflicts(only.isSelected()));
+    conflicts.add(next);
+    conflicts.add(prev);
+    conflicts.addSeparator();
+    conflicts.add(only);
+    planning.addReloadListener(() -> only.setSelected(planning.isFilterOnlyConflicts()));
+    return conflicts;
+  }
+
   private JMenuBar buildMenuBar() {
     JMenuBar bar = new JMenuBar();
+    bar.add(buildConflictsMenu());
 
     JMenu file = new JMenu(Language.tr("menu.file"));
     file.setMnemonic('F');

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -91,6 +91,7 @@ public class PlanningPanel extends JPanel {
   private String filterQuery = "";
   private String filterTags = "";
   private boolean filterNoConflicts;
+  private boolean filterOnlyConflicts;
 
   private static final int HEADER_H = 28;
   private static final int ROW_H = 60;
@@ -461,6 +462,18 @@ public class PlanningPanel extends JPanel {
       data = data.stream().filter(i -> visibleIds.contains(i.resourceId())).toList();
     }
     List<ConflictUtil.Conflict> computedConflicts = ConflictUtil.computeConflicts(data);
+    if (filterOnlyConflicts && !computedConflicts.isEmpty()) {
+      Set<String> conflictIds =
+          computedConflicts.stream()
+              .flatMap(c -> Stream.of(c.a().id(), c.b().id()))
+              .filter(id -> id != null && !id.isBlank())
+              .collect(Collectors.toSet());
+      data =
+          data.stream()
+              .filter(i -> i.id() != null && conflictIds.contains(i.id()))
+              .toList();
+      computedConflicts = ConflictUtil.computeConflicts(data);
+    }
     if (filterNoConflicts && !computedConflicts.isEmpty()) {
       Set<String> conflictIds =
           computedConflicts.stream()
@@ -665,6 +678,19 @@ public class PlanningPanel extends JPanel {
 
   public String getFilterTags() {
     return filterTags;
+  }
+
+  public boolean isFilterOnlyConflicts() {
+    return filterOnlyConflicts;
+  }
+
+  public void setFilterOnlyConflicts(boolean value) {
+    if (filterOnlyConflicts == value) {
+      return;
+    }
+    filterOnlyConflicts = value;
+    reload();
+    repaint();
   }
 
   public boolean isFilterNoConflicts() {
@@ -2129,5 +2155,13 @@ public class PlanningPanel extends JPanel {
     private Tile withAlpha(float a) {
       return new Tile(i, row, x1, x2, a);
     }
+  }
+
+  public void nextConflict() {
+    centerOn(pickNextConflict(false));
+  }
+
+  public void prevConflict() {
+    centerOn(pickNextConflict(true));
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Conflicts menu with navigation shortcuts and conflict-only toggle
- expose conflict navigation helpers on the planning panel and support filtering to only conflicting interventions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba27b49bc833080d570401f7bf062