### PR TITLE
Add configurable options to planning PDF export

### DIFF
--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -2043,7 +2043,14 @@ public class RestDataSource implements DataSourceProvider {
     http.close();
   }
 
-  public void uploadPlanningPngForPdf(Path png, String title, Path targetPdf) throws IOException {
+  public void uploadPlanningPngForPdf(
+      Path png,
+      String title,
+      String page,
+      String orientation,
+      Path logoPng,
+      Path targetPdf)
+      throws IOException {
     String url = baseUrl + "/api/v1/planning/pdf";
     HttpPost post = new HttpPost(url);
     applyHeaders(post);
@@ -2054,6 +2061,18 @@ public class RestDataSource implements DataSourceProvider {
             .addBinaryBody("image", bytes, ContentType.IMAGE_PNG, png.getFileName().toString());
     if (title != null && !title.isBlank()) {
       builder.addTextBody("title", title, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    }
+    builder.addTextBody(
+        "page",
+        page == null ? "auto" : page,
+        ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    builder.addTextBody(
+        "orientation",
+        orientation == null ? "auto" : orientation,
+        ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    if (logoPng != null) {
+      byte[] logoBytes = Files.readAllBytes(logoPng);
+      builder.addBinaryBody("logo", logoBytes, ContentType.IMAGE_PNG, logoPng.getFileName().toString());
     }
     post.setEntity(builder.build());
     try (CloseableHttpResponse response = http.execute(post)) {

--- a/server/src/main/java/com/location/server/api/v1/PlanningExportController.java
+++ b/server/src/main/java/com/location/server/api/v1/PlanningExportController.java
@@ -34,7 +34,10 @@ public class PlanningExportController {
   @PostMapping(value = "/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<byte[]> exportPdf(
       @RequestPart("image") MultipartFile image,
-      @RequestParam(value = "title", required = false) String title)
+      @RequestParam(value = "title", required = false) String title,
+      @RequestParam(value = "page", required = false) String page,
+      @RequestParam(value = "orientation", required = false) String orientation,
+      @RequestPart(value = "logo", required = false) MultipartFile logo)
       throws IOException {
     if (image == null || image.isEmpty()) {
       return ResponseEntity.badRequest().build();
@@ -43,12 +46,57 @@ public class PlanningExportController {
 
     byte[] pdfBytes;
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      byte[] imageBytes = image.getBytes();
+      Image probe = new Image(ImageDataFactory.create(imageBytes));
+      float rawWidth = probe.getImageWidth();
+      float rawHeight = probe.getImageHeight();
+      boolean hasDimensions = rawWidth > 0 && rawHeight > 0;
+      boolean wide = hasDimensions && rawWidth >= rawHeight;
+
+      PageSize basePageSize = null;
+      if (page != null && !page.equalsIgnoreCase("auto")) {
+        if (page.equalsIgnoreCase("A3")) {
+          basePageSize = PageSize.A3;
+        } else if (page.equalsIgnoreCase("A4")) {
+          basePageSize = PageSize.A4;
+        }
+      }
+      if (basePageSize == null) {
+        basePageSize = wide ? PageSize.A3 : PageSize.A4;
+      }
+
+      boolean orientationAuto = orientation == null || orientation.equalsIgnoreCase("auto");
+      boolean orientationLandscape =
+          orientation != null && orientation.equalsIgnoreCase("landscape");
+
+      PageSize pageSize = basePageSize;
+      if (orientationAuto) {
+        if (wide) {
+          pageSize = pageSize.rotate();
+        }
+      } else if (orientationLandscape) {
+        pageSize = pageSize.rotate();
+      }
+
       try (PdfWriter writer = new PdfWriter(baos);
           PdfDocument pdf = new PdfDocument(writer);
-          Document doc = new Document(pdf, PageSize.A4)) {
+          Document doc = new Document(pdf, pageSize)) {
         doc.setMargins(20, 20, 30, 20);
 
-        Image img = new Image(ImageDataFactory.create(image.getBytes()));
+        if (logo != null && !logo.isEmpty()) {
+          Image lg = new Image(ImageDataFactory.create(logo.getBytes()));
+          float availableWidth =
+              doc.getPdfDocument().getDefaultPageSize().getWidth()
+                  - doc.getLeftMargin()
+                  - doc.getRightMargin();
+          float logoScale =
+              Math.min(1f, (availableWidth * 0.25f) / Math.max(1f, lg.getImageScaledWidth()));
+          lg.scale(logoScale, logoScale);
+          lg.setHorizontalAlignment(HorizontalAlignment.CENTER);
+          doc.add(lg);
+        }
+
+        Image img = new Image(ImageDataFactory.create(imageBytes));
 
         float maxWidth =
             doc.getPdfDocument().getDefaultPageSize().getWidth()
@@ -58,12 +106,8 @@ public class PlanningExportController {
             doc.getPdfDocument().getDefaultPageSize().getHeight()
                 - doc.getTopMargin()
                 - doc.getBottomMargin();
-        float imageWidth = img.getImageWidth();
-        float imageHeight = img.getImageHeight();
-        if (imageWidth <= 0 || imageHeight <= 0) {
-          imageWidth = maxWidth;
-          imageHeight = maxHeight;
-        }
+        float imageWidth = hasDimensions ? rawWidth : maxWidth;
+        float imageHeight = hasDimensions ? rawHeight : maxHeight;
         float scale = Math.min(maxWidth / imageWidth, maxHeight / imageHeight);
         img.scale(scale, scale);
         img.setHorizontalAlignment(HorizontalAlignment.CENTER);


### PR DESCRIPTION
## Summary
- add optional page size, orientation, and logo parameters to the planning PDF export endpoint with automatic fallbacks based on the image
- update the REST client to send the new parameters and optional logo when exporting a planning PDF
- provide a Swing dialog so users can pick start date, paper size, orientation, and logo before exporting a planning PDF

## Testing
- mvn -pl server -am -DskipTests package *(fails: unable to download dependencies from Maven Central in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dba7f5d7148330a0215c0e89113033