### PR TITLE
Enhance planning PDF export metadata

### DIFF
--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -2049,6 +2049,9 @@ public class RestDataSource implements DataSourceProvider {
       String page,
       String orientation,
       Path logoPng,
+      String agency,
+      String period,
+      String recapText,
       Path targetPdf)
       throws IOException {
     String url = baseUrl + "/api/v1/planning/pdf";
@@ -2070,6 +2073,18 @@ public class RestDataSource implements DataSourceProvider {
         "orientation",
         orientation == null ? "auto" : orientation,
         ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    if (agency != null && !agency.isBlank()) {
+      builder.addTextBody(
+          "agency", agency, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    }
+    if (period != null && !period.isBlank()) {
+      builder.addTextBody(
+          "period", period, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    }
+    if (recapText != null && !recapText.isBlank()) {
+      builder.addTextBody(
+          "recapText", recapText, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8));
+    }
     if (logoPng != null) {
       byte[] logoBytes = Files.readAllBytes(logoPng);
       builder.addBinaryBody("logo", logoBytes, ContentType.IMAGE_PNG, logoPng.getFileName().toString());

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -2183,4 +2183,26 @@ public class PlanningPanel extends JPanel {
   public void prevConflict() {
     centerOn(pickNextConflict(true));
   }
+
+  public java.util.Map<String, Integer> getVisibleRecapByResource() {
+    java.util.Map<String, Integer> counts = new java.util.LinkedHashMap<>();
+    if (resources == null || interventions == null) {
+      return counts;
+    }
+    java.util.Map<String, String> nameById = new java.util.HashMap<>();
+    for (Models.Resource resource : resources) {
+      nameById.put(resource.id(), resource.name());
+      counts.put(resource.name(), 0);
+    }
+    for (Models.Intervention intervention : interventions) {
+      if (intervention.resourceId() == null) {
+        continue;
+      }
+      String name = nameById.get(intervention.resourceId());
+      if (name != null) {
+        counts.put(name, counts.getOrDefault(name, 0) + 1);
+      }
+    }
+    return counts;
+  }
 }


### PR DESCRIPTION
## Summary
- add agency, period, and optional recap data to the planning PDF export and support larger A1/A2 page sizes
- extend the client export dialog to capture agency metadata and recap options and send them to the server
- provide a resource-level recap calculation for the planning view used during export

## Testing
- mvn -pl server test *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dbaa8d8d3083309435db0d79c3d93c