### PR TITLE
Enhance planning command palette

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
@@ -414,9 +415,9 @@ public class MainFrame extends JFrame {
                 deleteSelected();
               }
             });
-    getRootPane()
-        .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke("control K"), "commandPalette");
+    InputMap paletteInput = getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+    paletteInput.put(KeyStroke.getKeyStroke("control K"), "commandPalette");
+    paletteInput.put(KeyStroke.getKeyStroke("meta K"), "commandPalette");
     getRootPane()
         .getActionMap()
         .put(
@@ -1125,23 +1126,66 @@ public class MainFrame extends JFrame {
 
   private void openCommandPalette() {
     CommandPaletteDialog dialog =
-        new CommandPaletteDialog(this)
-            .commands(
-                new CommandPaletteDialog.Command(
-                    "planning", "Aller au planning", () -> handleNavigation("planning")),
-                new CommandPaletteDialog.Command(
-                    "docs", "Ouvrir les documents", () -> handleNavigation("docs")),
-                new CommandPaletteDialog.Command(
-                    "new-intervention",
-                    "Nouvelle intervention",
-                    this::createInterventionDialog),
-                new CommandPaletteDialog.Command(
-                    "global-search", "Recherche globale", this::openGlobalSearch),
-                new CommandPaletteDialog.Command(
-                    "theme-light", "Thème clair", () -> Theme.apply(Theme.Mode.LIGHT)),
-                new CommandPaletteDialog.Command(
-                    "theme-dark", "Thème sombre", () -> Theme.apply(Theme.Mode.DARK)));
+        new CommandPaletteDialog(this).commands(buildCommandPaletteCommands());
     dialog.setVisible(true);
+  }
+
+  private CommandPaletteDialog.Command[] buildCommandPaletteCommands() {
+    List<CommandPaletteDialog.Command> commands = new ArrayList<>();
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning", "Aller au planning", () -> handleNavigation("planning")));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "docs", "Ouvrir les documents", () -> handleNavigation("docs")));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "new-intervention",
+            "Nouvelle intervention",
+            this::createInterventionDialog));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "global-search", "Recherche globale", this::openGlobalSearch));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning-today",
+            "Aller à aujourd'hui",
+            () -> {
+              planning.setDay(LocalDate.now());
+              planning.reload();
+            }));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning-next-conflict", "Planning: prochain conflit", planning::nextConflict));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning-prev-conflict", "Planning: conflit précédent", planning::prevConflict));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning-only-conflicts",
+            "Planning: afficher uniquement les conflits",
+            () -> planning.setFilterOnlyConflicts(true)));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning-all",
+            "Planning: afficher tous",
+            () -> planning.setFilterOnlyConflicts(false)));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "export-png-view", "Export PNG (vue)", this::exportPlanningPngDialog));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "export-png-full", "Export PNG (complet)", this::exportPlanningPngFullDialog));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "export-pdf-full", "Export PDF (complet)", this::exportPlanningPdfFullDialog));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "theme-light", "Thème clair", () -> Theme.apply(Theme.Mode.LIGHT)));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "theme-dark", "Thème sombre", () -> Theme.apply(Theme.Mode.DARK)));
+    return commands.toArray(new CommandPaletteDialog.Command[0]);
   }
 
   private void openGlobalSearch() {

--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -2205,4 +2205,21 @@ public class PlanningPanel extends JPanel {
     }
     return counts;
   }
+
+  public void quickFind(String query) {
+    if (query == null || query.isBlank() || interventions == null) {
+      return;
+    }
+    String needle = query.toLowerCase(Locale.ROOT).trim();
+    for (Models.Intervention intervention : interventions) {
+      if (intervention == null) {
+        continue;
+      }
+      String title = intervention.title();
+      if (title != null && title.toLowerCase(Locale.ROOT).contains(needle)) {
+        centerOn(intervention);
+        return;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a macOS shortcut for the command palette and centralize command registration
- extend the command palette with planning navigation and export actions
- expose a quickFind helper on the planning panel to center on matching interventions

## Testing
- `mvn -pl client -am -DskipTests compile` *(fails: Maven cannot download org.springframework.boot:spring-boot-dependencies due to HTTP 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb61b97c88330a899a605b2f7550a