### PR TITLE
Add intervention tag inspector and tagging API

### DIFF
--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -274,6 +274,14 @@ public interface DataSourceProvider extends AutoCloseable {
         "deleteRecurringUnavailability non disponible dans " + getLabel());
   }
 
+  default java.util.List<String> getInterventionTags(String interventionId) {
+    throw new UnsupportedOperationException("getInterventionTags non disponible dans " + getLabel());
+  }
+
+  default void setInterventionTags(String interventionId, java.util.List<String> tags) {
+    throw new UnsupportedOperationException("setInterventionTags non disponible dans " + getLabel());
+  }
+
   static String merge(String template, java.util.Map<String, String> context) {
     if (template == null || template.isBlank()) {
       return "";

--- a/client/src/main/java/com/location/client/core/MockDataSource.java
+++ b/client/src/main/java/com/location/client/core/MockDataSource.java
@@ -18,8 +18,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MockDataSource implements DataSourceProvider {
+
+  private final Map<String, List<String>> interventionTags = new ConcurrentHashMap<>();
 
   private final List<Models.Agency> agencies = new ArrayList<>();
   private final List<Models.Client> clients = new ArrayList<>();
@@ -62,6 +65,22 @@ public class MockDataSource implements DataSourceProvider {
   @Override
   public String getLabel() {
     return "MOCK";
+  }
+
+  @Override
+  public List<String> getInterventionTags(String interventionId) {
+    if (interventionId == null) {
+      return List.of();
+    }
+    return interventionTags.getOrDefault(interventionId, List.of());
+  }
+
+  @Override
+  public void setInterventionTags(String interventionId, List<String> tags) {
+    if (interventionId == null) {
+      return;
+    }
+    interventionTags.put(interventionId, tags == null ? List.of() : new ArrayList<>(tags));
   }
 
   @Override

--- a/client/src/main/java/com/location/client/core/Preferences.java
+++ b/client/src/main/java/com/location/client/core/Preferences.java
@@ -189,6 +189,14 @@ public class Preferences {
     props.setProperty("filterTags", value == null ? "" : value);
   }
 
+  public String getInterventionTagFilter() {
+    return props.getProperty("filterInterventionTags", "");
+  }
+
+  public void setInterventionTagFilter(String value) {
+    props.setProperty("filterInterventionTags", value == null ? "" : value);
+  }
+
   public String getDayIso() {
     String value = props.getProperty("planning.lastDay");
     if (value == null || value.isBlank()) {

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -11,6 +11,7 @@ import com.location.client.ui.uikit.Svg;
 import com.location.client.ui.uikit.Toasts;
 import java.awt.BorderLayout;
 import java.awt.Desktop;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -47,6 +48,7 @@ public class MainFrame extends JFrame {
   private final Preferences prefs;
   private final PlanningPanel planning;
   private final PlanningMinimap minimap;
+  private final PlanningInspector inspector;
   private final JPanel centerCards = new JPanel(new java.awt.CardLayout());
   private JPanel clientsPanel;
   private JPanel unavPanel;
@@ -76,6 +78,7 @@ public class MainFrame extends JFrame {
     ResourceColors.initialize(prefs);
     this.planning = new PlanningPanel(dsp);
     this.minimap = new PlanningMinimap();
+    this.inspector = new PlanningInspector(dsp);
     this.topBar = new TopBar(planning, prefs);
     this.sidebar = new Sidebar(this::handleNavigation);
     minimap.setWorkingHours(planning.getStartHour(), planning.getEndHour());
@@ -136,7 +139,9 @@ public class MainFrame extends JFrame {
     add(topBar, BorderLayout.NORTH);
     add(sidebar, BorderLayout.WEST);
     JPanel planningContainer = new JPanel(new BorderLayout());
+    inspector.setPreferredSize(new Dimension(320, 600));
     planningContainer.add(planning, BorderLayout.CENTER);
+    planningContainer.add(inspector, BorderLayout.EAST);
     planningContainer.add(minimap, BorderLayout.SOUTH);
 
     centerCards.add(planningContainer, "planning");
@@ -158,6 +163,22 @@ public class MainFrame extends JFrame {
               @Override
               public void actionPerformed(ActionEvent e) {
                 planning.duplicateSelected();
+              }
+            }));
+    selectionBar.add(
+        new JButton(
+            new AbstractAction("Dupliquer +1j") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                planning.duplicateSelected(1);
+              }
+            }));
+    selectionBar.add(
+        new JButton(
+            new AbstractAction("Dupliquer +7j") {
+              @Override
+              public void actionPerformed(ActionEvent e) {
+                planning.duplicateSelected(7);
               }
             }));
     selectionBar.add(
@@ -190,6 +211,7 @@ public class MainFrame extends JFrame {
           suggestionPanel.showFor(selection, dayItems);
           boolean hasSelection = !selection.isEmpty();
           selectionBar.setVisible(hasSelection);
+          inspector.showIntervention(hasSelection ? selection.get(0) : null);
           if (hasSelection) {
             int count = selection.size();
             selectionInfo.setText(count == 1 ? "1 sélectionnée" : count + " sélectionnées");

--- a/client/src/main/java/com/location/client/ui/PlanningInspector.java
+++ b/client/src/main/java/com/location/client/ui/PlanningInspector.java
@@ -1,0 +1,91 @@
+package com.location.client.ui;
+
+import com.location.client.core.DataSourceProvider;
+import com.location.client.core.Models;
+import java.awt.BorderLayout;
+import java.awt.Font;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+
+public class PlanningInspector extends JPanel {
+  private final DataSourceProvider dataSource;
+  private final JLabel title = new JLabel("—");
+  private final JTextArea notes = new JTextArea(6, 24);
+  private final JTextField tags = new JTextField(24);
+  private Models.Intervention current;
+
+  public PlanningInspector(DataSourceProvider dataSource) {
+    super(new BorderLayout(8, 8));
+    this.dataSource = dataSource;
+    setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+    setOpaque(false);
+
+    JPanel content = new JPanel();
+    content.setOpaque(false);
+    content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
+
+    title.setFont(title.getFont().deriveFont(Font.BOLD, 14f));
+    content.add(title);
+    content.add(Box.createVerticalStrut(8));
+
+    content.add(new JLabel("Notes internes:"));
+    notes.setEditable(false);
+    notes.setLineWrap(true);
+    notes.setWrapStyleWord(true);
+    content.add(new JScrollPane(notes));
+
+    content.add(Box.createVerticalStrut(8));
+    content.add(new JLabel("Tags (séparés par des virgules):"));
+    content.add(tags);
+    JButton save = new JButton("Enregistrer les tags");
+    save.addActionListener(e -> persistTags());
+    content.add(Box.createVerticalStrut(8));
+    content.add(save);
+
+    add(content, BorderLayout.NORTH);
+  }
+
+  public void showIntervention(Models.Intervention intervention) {
+    current = intervention;
+    if (intervention == null) {
+      title.setText("—");
+      notes.setText("");
+      tags.setText("");
+      return;
+    }
+    title.setText(intervention.title() == null ? "(Sans titre)" : intervention.title());
+    notes.setText(intervention.notes() == null ? "" : intervention.notes());
+    try {
+      List<String> tagList = dataSource.getInterventionTags(intervention.id());
+      tags.setText(String.join(", ", tagList));
+    } catch (RuntimeException ex) {
+      tags.setText("");
+    }
+  }
+
+  private void persistTags() {
+    if (current == null) {
+      return;
+    }
+    List<String> tagList =
+        Arrays.stream(tags.getText().split(","))
+            .map(String::trim)
+            .filter(token -> !token.isBlank())
+            .collect(Collectors.toList());
+    try {
+      dataSource.setInterventionTags(current.id(), tagList);
+    } catch (RuntimeException ex) {
+      // Best effort only; errors are silently ignored for now.
+    }
+  }
+}

--- a/client/src/main/java/com/location/client/ui/TopBar.java
+++ b/client/src/main/java/com/location/client/ui/TopBar.java
@@ -31,6 +31,7 @@ public class TopBar extends JPanel {
   private final JComboBox<Models.Client> cbClient = new JComboBox<>();
   private final JTextField tfQuery = new JTextField();
   private final JTextField tfTags = new JTextField();
+  private final JTextField tfInterventionTags = new JTextField();
   private final JCheckBox cbNoConflicts = new JCheckBox("Sans conflit");
   private final JSpinner spDate = new JSpinner(new SpinnerDateModel());
   private boolean updating = false;
@@ -131,6 +132,17 @@ public class TopBar extends JPanel {
           preferences.save();
         });
 
+    tfInterventionTags.setColumns(12);
+    tfInterventionTags.addActionListener(
+        e -> {
+          if (updating) {
+            return;
+          }
+          planning.setTagFilter(tfInterventionTags.getText());
+          preferences.setInterventionTagFilter(tfInterventionTags.getText());
+          preferences.save();
+        });
+
     cbNoConflicts.setFocusable(false);
     cbNoConflicts.addActionListener(
         e -> {
@@ -148,8 +160,10 @@ public class TopBar extends JPanel {
     right.add(cbClient);
     right.add(new JLabel("Recherche:"));
     right.add(tfQuery);
-    right.add(new JLabel("Tags:"));
+    right.add(new JLabel("Tags ressource:"));
     right.add(tfTags);
+    right.add(new JLabel("Tags intervention:"));
+    right.add(tfInterventionTags);
     right.add(cbNoConflicts);
 
     add(left, BorderLayout.WEST);
@@ -167,6 +181,9 @@ public class TopBar extends JPanel {
     String savedTags = preferences.getFilterTags();
     tfTags.setText(savedTags);
     planning.setFilterTags(savedTags);
+    String savedInterventionTags = preferences.getInterventionTagFilter();
+    tfInterventionTags.setText(savedInterventionTags);
+    planning.setTagFilter(savedInterventionTags);
     updating = true;
     try {
       cbNoConflicts.setSelected(planning.isFilterNoConflicts());

--- a/server/src/main/java/com/location/server/api/v1/InterventionTagsController.java
+++ b/server/src/main/java/com/location/server/api/v1/InterventionTagsController.java
@@ -1,0 +1,39 @@
+package com.location.server.api.v1;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/interventions")
+public class InterventionTagsController {
+
+  private final Map<String, List<String>> tagsByIntervention = new ConcurrentHashMap<>();
+
+  @GetMapping(value = "/{id}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<List<String>> getTags(@PathVariable("id") String id) {
+    if (id == null || id.isBlank()) {
+      return ResponseEntity.ok(List.of());
+    }
+    return ResponseEntity.ok(tagsByIntervention.getOrDefault(id, List.of()));
+  }
+
+  @PostMapping(value = "/{id}/tags", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Void> setTags(
+      @PathVariable("id") String id, @RequestBody(required = false) List<String> tags) {
+    if (id == null || id.isBlank()) {
+      return ResponseEntity.ok().build();
+    }
+    tagsByIntervention.put(id, tags == null ? List.of() : new ArrayList<>(tags));
+    return ResponseEntity.ok().build();
+  }
+}


### PR DESCRIPTION
## Summary
- add intervention tag persistence hooks to the data sources and expose a REST endpoint on the server mock
- surface intervention tag filtering, duplication shortcuts, and a planning inspector panel in the client UI
- persist the new intervention tag filter in preferences alongside existing resource filters

## Testing
- mvn -pl client -am -DskipTests compile *(fails: Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbf6c40308330a5282f99c530ec64