### PR TITLE
Add planning tag chips and palette duplication commands

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -1198,6 +1198,16 @@ public class MainFrame extends JFrame {
             () -> planning.setFilterOnlyConflicts(false)));
     commands.add(
         new CommandPaletteDialog.Command(
+            "planning-duplicate-plus-one",
+            "Dupliquer +1 jour",
+            () -> planning.duplicateSelected(1)));
+    commands.add(
+        new CommandPaletteDialog.Command(
+            "planning-duplicate-plus-seven",
+            "Dupliquer +7 jours",
+            () -> planning.duplicateSelected(7)));
+    commands.add(
+        new CommandPaletteDialog.Command(
             "export-png-view", "Export PNG (vue)", this::exportPlanningPngDialog));
     commands.add(
         new CommandPaletteDialog.Command(

--- a/client/src/main/java/com/location/client/ui/uikit/Chip.java
+++ b/client/src/main/java/com/location/client/ui/uikit/Chip.java
@@ -1,0 +1,36 @@
+package com.location.client.ui.uikit;
+
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.RenderingHints;
+import javax.swing.JToggleButton;
+
+public class Chip extends JToggleButton {
+  public Chip(String label) {
+    super(label);
+    setFocusPainted(false);
+    setBorderPainted(false);
+    setContentAreaFilled(false);
+    setMargin(new Insets(4, 10, 4, 10));
+    setOpaque(false);
+    setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+  }
+
+  @Override
+  protected void paintComponent(Graphics graphics) {
+    Graphics2D g2 = (Graphics2D) graphics.create();
+    g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+    int arc = 16;
+    Color border = isSelected() ? new Color(59, 130, 246) : new Color(203, 213, 225);
+    Color fill = isSelected() ? new Color(59, 130, 246, 40) : new Color(203, 213, 225, 40);
+    g2.setColor(fill);
+    g2.fillRoundRect(0, 0, getWidth(), getHeight(), arc, arc);
+    g2.setColor(border);
+    g2.drawRoundRect(0, 0, getWidth() - 1, getHeight() - 1, arc, arc);
+    g2.dispose();
+    super.paintComponent(graphics);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable chip toggle button for suggested planning tags
- integrate chip suggestions into the planning inspector and sync tag updates
- expose +1 day and +7 days planning duplication shortcuts in the command palette

## Testing
- mvn -pl client -am -DskipTests compile *(fails: dependency download blocked by 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc397594c8330808a48b001ef6ae8