### PR TITLE
Expose additional bindings for document templates

### DIFF
--- a/server/src/main/java/com/location/server/service/TemplateService.java
+++ b/server/src/main/java/com/location/server/service/TemplateService.java
@@ -88,15 +88,23 @@ public class TemplateService {
     bindings.put("agencyName", document.getAgency().getName());
     bindings.put("clientName", document.getClient().getName());
     bindings.put("clientEmail", nullToEmpty(document.getClient().getEmail()));
+    bindings.put("clientPhone", nullToEmpty(document.getClient().getPhone()));
     bindings.put("clientAddress", nullToEmpty(document.getClient().getAddress()));
     bindings.put("clientZip", nullToEmpty(document.getClient().getZip()));
     bindings.put("clientCity", nullToEmpty(document.getClient().getCity()));
     bindings.put("clientVatNumber", nullToEmpty(document.getClient().getVatNumber()));
     bindings.put("clientIban", nullToEmpty(document.getClient().getIban()));
+    bindings.put("agencyLegalFooter", nullToEmpty(document.getAgency().getLegalFooter()));
+    bindings.put("agencyIban", nullToEmpty(document.getAgency().getIban()));
     bindings.put("docRef", nullToEmpty(document.getReference()));
     bindings.put("docTitle", nullToEmpty(document.getTitle()));
     bindings.put("docType", document.getType().name());
+    bindings.put("docStatus", document.getStatus().name());
     bindings.put("docDate", document.getDate() == null ? "" : document.getDate().toLocalDate().toString());
+    bindings.put("docDelivered", Boolean.toString(document.isDelivered()));
+    bindings.put("docPaid", Boolean.toString(document.isPaid()));
+    bindings.put("totalHt", document.getTotalHt().toPlainString());
+    bindings.put("totalVat", document.getTotalVat().toPlainString());
     bindings.put("totalTtc", document.getTotalTtc().toPlainString());
     return bindings;
   }

--- a/server/src/test/java/com/location/server/service/TemplateServiceTest.java
+++ b/server/src/test/java/com/location/server/service/TemplateServiceTest.java
@@ -4,14 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.location.server.domain.Agency;
 import com.location.server.domain.Client;
+import com.location.server.domain.CommercialDocument;
 import com.location.server.domain.Intervention;
 import com.location.server.domain.Resource;
 import com.location.server.repo.AgencyRepository;
 import com.location.server.repo.ClientRepository;
 import com.location.server.repo.InterventionRepository;
 import com.location.server.repo.ResourceRepository;
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,5 +62,52 @@ class TemplateServiceTest {
         .contains("Levage")
         .contains("2025-01-01 08:00")
         .contains("2025-01-01 10:00");
+  }
+
+  @Test
+  void documentBindingsExposeAgencyClientAndTotals() {
+    var agency = new Agency("A2", "Agence Sud");
+    agency.setLegalFooter("SARL Agence Sud – RCS 123 456 789");
+    agency.setIban("FR76 3000 6000 1111 2222 3333 444");
+    var client =
+        new Client(
+            "C2",
+            "Client Beta",
+            "beta@example.test",
+            "06 12 34 56 78",
+            "10 Rue des Tests",
+            "75000",
+            "Paris",
+            "FR123456789",
+            "FR76 1234 5678 9000");
+    var document =
+        new CommercialDocument(
+            "D1",
+            CommercialDocument.DocType.ORDER,
+            CommercialDocument.DocStatus.SENT,
+            "CMD-2025-01",
+            "Levage 90T",
+            OffsetDateTime.of(2025, 2, 10, 0, 0, 0, 0, ZoneOffset.UTC),
+            agency,
+            client);
+    document.setTotals(new BigDecimal("1200.00"), new BigDecimal("240.00"), new BigDecimal("1440.00"));
+    document.setDelivered(true);
+    document.setPaid(false);
+
+    Map<String, String> bindings = templateService.documentBindings(document);
+
+    assertThat(bindings)
+        .containsEntry("agencyName", "Agence Sud")
+        .containsEntry("agencyLegalFooter", "SARL Agence Sud – RCS 123 456 789")
+        .containsEntry("agencyIban", "FR76 3000 6000 1111 2222 3333 444")
+        .containsEntry("clientName", "Client Beta")
+        .containsEntry("clientPhone", "06 12 34 56 78")
+        .containsEntry("clientEmail", "beta@example.test")
+        .containsEntry("docStatus", "SENT")
+        .containsEntry("docDelivered", "true")
+        .containsEntry("docPaid", "false")
+        .containsEntry("totalHt", "1200.00")
+        .containsEntry("totalVat", "240.00")
+        .containsEntry("totalTtc", "1440.00");
   }
 }


### PR DESCRIPTION
## Summary
- extend TemplateService document bindings with agency contact, totals, status, and delivery flags
- include client phone information when building template placeholders
- add a regression test covering the expanded bindings

## Testing
- mvn -pl server test *(fails: unable to download Maven dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcf1fb9b4833097d3fc7c36b3b7f4