### PR TITLE
Add mail sending API endpoint and configuration example

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -76,6 +76,10 @@
       <artifactId>openpdf</artifactId>
       <version>1.3.32</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/server/src/main/java/com/location/server/api/v1/MailController.java
+++ b/server/src/main/java/com/location/server/api/v1/MailController.java
@@ -1,0 +1,38 @@
+package com.location.server.api.v1;
+
+import com.location.server.service.MailService;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mail")
+public class MailController {
+  @Autowired private MailService mailService;
+
+  @PostMapping(value = "/send", consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> send(@RequestBody Map<String, Object> payload) {
+    try {
+      Object to = payload.get("to");
+      String subject = (String) payload.getOrDefault("subject", "");
+      String html = (String) payload.getOrDefault("html", "");
+      String from = (String) payload.getOrDefault("from", "");
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> attachments = (List<Map<String, Object>>) payload.get("attachments");
+      @SuppressWarnings("unchecked")
+      List<String> cc = (List<String>) payload.get("cc");
+      @SuppressWarnings("unchecked")
+      List<String> bcc = (List<String>) payload.get("bcc");
+      mailService.send(to, subject, html, attachments, cc, bcc, from);
+      return ResponseEntity.accepted().build();
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+    }
+  }
+}

--- a/server/src/main/java/com/location/server/service/MailService.java
+++ b/server/src/main/java/com/location/server/service/MailService.java
@@ -1,0 +1,80 @@
+package com.location.server.service;
+
+import jakarta.mail.internet.MimeMessage;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailService {
+  private final JavaMailSender mailSender;
+
+  @Value("${app.mail.from:}")
+  private String defaultFrom;
+
+  public MailService(JavaMailSender mailSender) {
+    this.mailSender = mailSender;
+  }
+
+  public void send(
+      Object to,
+      String subject,
+      String html,
+      List<Map<String, Object>> attachments,
+      List<String> cc,
+      List<String> bcc,
+      String from)
+      throws Exception {
+    MimeMessage message = mailSender.createMimeMessage();
+    boolean multipart = attachments != null && !attachments.isEmpty();
+    MimeMessageHelper helper = new MimeMessageHelper(message, multipart, "UTF-8");
+
+    String effectiveFrom = (from == null || from.isBlank()) ? defaultFrom : from;
+    if (effectiveFrom != null && !effectiveFrom.isBlank()) {
+      helper.setFrom(effectiveFrom);
+    }
+
+    if (to instanceof String s) {
+      helper.setTo(s);
+    } else if (to instanceof List<?> list) {
+      helper.setTo(list.stream().map(Object::toString).toArray(String[]::new));
+    } else {
+      throw new IllegalArgumentException("Invalid 'to' type");
+    }
+
+    if (cc != null && !cc.isEmpty()) {
+      helper.setCc(cc.toArray(new String[0]));
+    }
+    if (bcc != null && !bcc.isEmpty()) {
+      helper.setBcc(bcc.toArray(new String[0]));
+    }
+
+    helper.setSubject(subject == null ? "" : subject);
+    helper.setText(html == null ? "" : html, true);
+
+    if (multipart) {
+      for (Map<String, Object> attachment : attachments) {
+        String name = String.valueOf(attachment.getOrDefault("filename", "attachment"));
+        String base64 = String.valueOf(attachment.get("base64"));
+        String contentType =
+            String.valueOf(attachment.getOrDefault("contentType", "application/octet-stream"));
+        byte[] data = Base64.getDecoder().decode(base64);
+        ByteArrayResource resource =
+            new ByteArrayResource(data) {
+              @Override
+              public String getFilename() {
+                return name;
+              }
+            };
+        helper.addAttachment(name, resource, contentType);
+      }
+    }
+
+    mailSender.send(message);
+  }
+}

--- a/server/src/main/resources/application-mail-example.properties
+++ b/server/src/main/resources/application-mail-example.properties
@@ -1,0 +1,8 @@
+# SMTP example config
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=you@example.com
+spring.mail.password=YOUR_APP_PASSWORD
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+app.mail.from=Location App <no-reply@example.com>


### PR DESCRIPTION
## Summary
- add Spring Boot mail starter dependency to the server module
- implement a MailService and API controller to send emails with optional attachments and CC/BCC
- provide an example mail configuration properties file for SMTP setup

## Testing
- `mvn -pl server -am test` *(fails: unable to download spring-boot-dependencies 3.3.2 from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe7c5051083308817969c79439176