### PR TITLE
Improve mail API validation and client logging

### DIFF
--- a/client/src/main/java/com/location/client/core/Preferences.java
+++ b/client/src/main/java/com/location/client/core/Preferences.java
@@ -4,10 +4,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Preferences {
   private final Properties props = new Properties();
   private final Path file;
+  private static final Logger LOGGER = Logger.getLogger(Preferences.class.getName());
 
   private Preferences(Path file) {
     this.file = file;
@@ -17,14 +20,16 @@ public class Preferences {
     Path home = Path.of(System.getProperty("user.home"), ".location");
     try {
       Files.createDirectories(home);
-    } catch (IOException ignored) {
+    } catch (IOException ex) {
+      LOGGER.log(Level.WARNING, "Impossible de créer le répertoire des préférences " + home, ex);
     }
     Path file = home.resolve("app.properties");
     Preferences prefs = new Preferences(file);
     if (Files.exists(file)) {
       try (var in = Files.newInputStream(file)) {
         prefs.props.load(in);
-      } catch (IOException ignored) {
+      } catch (IOException ex) {
+        LOGGER.log(Level.WARNING, "Impossible de charger les préférences depuis " + file, ex);
       }
     }
     prefs.props.putIfAbsent("baseUrl", "http://localhost:8080");
@@ -36,7 +41,8 @@ public class Preferences {
   public void save() {
     try (var out = Files.newOutputStream(file)) {
       props.store(out, "LOCATION");
-    } catch (IOException ignored) {
+    } catch (IOException ex) {
+      LOGGER.log(Level.WARNING, "Impossible d'enregistrer les préférences vers " + file, ex);
     }
   }
 

--- a/client/src/main/java/com/location/client/core/RestDataSource.java
+++ b/client/src/main/java/com/location/client/core/RestDataSource.java
@@ -1945,6 +1945,7 @@ public class RestDataSource implements DataSourceProvider {
   }
 
   private void applyHeaders(ClassicHttpRequest request) {
+    request.addHeader("User-Agent", "LocationApp/1.0");
     String token = bearer.get();
     if (token != null && !token.isBlank()) {
       request.addHeader("Authorization", "Bearer " + token);

--- a/client/src/main/java/com/location/client/ui/DocumentsBrowserFrame.java
+++ b/client/src/main/java/com/location/client/ui/DocumentsBrowserFrame.java
@@ -8,6 +8,8 @@ import java.awt.event.ActionEvent;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.swing.*;
 
@@ -15,6 +17,7 @@ import javax.swing.*;
  * Fenêtre de raccourcis permettant d'ouvrir l'explorateur de documents filtré par type.
  */
 public class DocumentsBrowserFrame extends JFrame {
+  private static final Logger LOGGER = Logger.getLogger(DocumentsBrowserFrame.class.getName());
   private final DataSourceProvider dataSourceProvider;
 
   public DocumentsBrowserFrame(DataSourceProvider dataSourceProvider) {
@@ -39,7 +42,8 @@ public class DocumentsBrowserFrame extends JFrame {
         invoicesUnpaid =
             docs.stream().filter(d -> "INVOICE".equals(d.type()) && !d.paid()).count();
       }
-    } catch (Exception ignored) {
+    } catch (Exception ex) {
+      LOGGER.log(Level.WARNING, "Impossible de charger les documents", ex);
     }
 
     JPanel panel = new JPanel(new GridLayout(0, 1, 8, 8));

--- a/client/src/main/java/com/location/client/ui/Theme.java
+++ b/client/src/main/java/com/location/client/ui/Theme.java
@@ -7,11 +7,14 @@ import com.location.client.core.Preferences;
 import java.awt.Font;
 import java.awt.Window;
 import java.util.Enumeration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.SwingUtilities;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 
 public final class Theme {
+  private static final Logger LOGGER = Logger.getLogger(Theme.class.getName());
   public enum Mode { LIGHT, DARK }
 
   private static Preferences preferences;
@@ -65,7 +68,7 @@ public final class Theme {
         }
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.log(Level.SEVERE, "Impossible d'appliquer le thème", e);
     }
   }
 
@@ -75,7 +78,8 @@ public final class Theme {
       if (saved != null) {
         try {
           return Mode.valueOf(saved);
-        } catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ex) {
+          LOGGER.log(Level.WARNING, "Mode de thème inconnu dans les préférences: " + saved, ex);
         }
       }
     }

--- a/server/src/main/java/com/location/server/api/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/location/server/api/GlobalExceptionHandler.java
@@ -1,0 +1,65 @@
+package com.location.server.api;
+
+import jakarta.validation.ConstraintViolationException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String, Object>> handleValidation(
+      MethodArgumentNotValidException ex, WebRequest request) {
+    Map<String, Object> body = base(request);
+    body.put("status", HttpStatus.BAD_REQUEST.value());
+    body.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());
+    body.put(
+        "message",
+        ex.getBindingResult().getFieldErrors().stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .collect(Collectors.joining("; ")));
+    return ResponseEntity.badRequest().body(body);
+  }
+
+  @ExceptionHandler({ConstraintViolationException.class, IllegalArgumentException.class})
+  public ResponseEntity<Map<String, Object>> handleBadRequest(
+      RuntimeException ex, WebRequest request) {
+    Map<String, Object> body = base(request);
+    body.put("status", HttpStatus.BAD_REQUEST.value());
+    body.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());
+    body.put("message", ex.getMessage());
+    return ResponseEntity.badRequest().body(body);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Map<String, Object>> handleAny(Exception ex, WebRequest request) {
+    LOGGER.error("Unexpected error while processing request", ex);
+    Map<String, Object> body = base(request);
+    body.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+    body.put("error", HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+    body.put("message", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+  }
+
+  private Map<String, Object> base(WebRequest request) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("timestamp", Instant.now().toString());
+    if (request instanceof ServletWebRequest servletRequest) {
+      body.put("path", servletRequest.getRequest().getRequestURI());
+      body.put("method", servletRequest.getRequest().getMethod());
+    }
+    return body;
+  }
+}

--- a/server/src/main/java/com/location/server/api/v1/MailController.java
+++ b/server/src/main/java/com/location/server/api/v1/MailController.java
@@ -1,9 +1,13 @@
 package com.location.server.api.v1;
 
+import com.location.server.api.v1.dto.MailSendRequest;
 import com.location.server.service.MailService;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,25 +18,48 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/mail")
 public class MailController {
-  @Autowired private MailService mailService;
+  private final MailService mailService;
+
+  public MailController(MailService mailService) {
+    this.mailService = mailService;
+  }
 
   @PostMapping(value = "/send", consumes = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> send(@RequestBody Map<String, Object> payload) {
-    try {
-      Object to = payload.get("to");
-      String subject = (String) payload.getOrDefault("subject", "");
-      String html = (String) payload.getOrDefault("html", "");
-      String from = (String) payload.getOrDefault("from", "");
-      @SuppressWarnings("unchecked")
-      List<Map<String, Object>> attachments = (List<Map<String, Object>>) payload.get("attachments");
-      @SuppressWarnings("unchecked")
-      List<String> cc = (List<String>) payload.get("cc");
-      @SuppressWarnings("unchecked")
-      List<String> bcc = (List<String>) payload.get("bcc");
-      mailService.send(to, subject, html, attachments, cc, bcc, from);
-      return ResponseEntity.accepted().build();
-    } catch (Exception e) {
-      return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+  public ResponseEntity<Void> send(@Valid @RequestBody MailSendRequest request) throws Exception {
+    List<String> recipients = resolveRecipients(request.getTo(), request.getToList());
+    List<Map<String, Object>> attachments = request.getAttachments();
+    mailService.send(
+        recipients,
+        request.getSubject(),
+        request.getHtml(),
+        attachments,
+        sanitizeAddresses(request.getCc()),
+        sanitizeAddresses(request.getBcc()),
+        request.getFrom());
+    return ResponseEntity.accepted().build();
+  }
+
+  private List<String> resolveRecipients(String single, List<String> list) {
+    List<String> fromList = sanitizeAddresses(list);
+    if (fromList != null && !fromList.isEmpty()) {
+      return fromList;
     }
+    if (single != null && !single.isBlank()) {
+      return List.of(single);
+    }
+    throw new IllegalArgumentException("Destinataire requis");
+  }
+
+  private List<String> sanitizeAddresses(List<String> addresses) {
+    if (addresses == null) {
+      return null;
+    }
+    List<String> sanitized =
+        addresses.stream()
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toCollection(ArrayList::new));
+    return sanitized.isEmpty() ? null : sanitized;
   }
 }

--- a/server/src/main/java/com/location/server/api/v1/dto/MailSendRequest.java
+++ b/server/src/main/java/com/location/server/api/v1/dto/MailSendRequest.java
@@ -1,0 +1,90 @@
+package com.location.server.api.v1.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+
+public class MailSendRequest {
+  @Email(message = "Destinataire invalide")
+  private String to;
+
+  private List<@Email(message = "Destinataire invalide") String> toList;
+
+  @NotBlank(message = "Sujet requis")
+  @Size(max = 200, message = "Sujet trop long")
+  private String subject;
+
+  @NotBlank(message = "Corps HTML requis")
+  private String html;
+
+  private String from;
+  private List<@Email(message = "CC invalide") String> cc;
+  private List<@Email(message = "BCC invalide") String> bcc;
+  private List<Map<String, Object>> attachments;
+
+  public String getTo() {
+    return to;
+  }
+
+  public void setTo(String to) {
+    this.to = to;
+  }
+
+  public List<String> getToList() {
+    return toList;
+  }
+
+  public void setToList(List<String> toList) {
+    this.toList = toList;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public String getHtml() {
+    return html;
+  }
+
+  public void setHtml(String html) {
+    this.html = html;
+  }
+
+  public String getFrom() {
+    return from;
+  }
+
+  public void setFrom(String from) {
+    this.from = from;
+  }
+
+  public List<String> getCc() {
+    return cc;
+  }
+
+  public void setCc(List<String> cc) {
+    this.cc = cc;
+  }
+
+  public List<String> getBcc() {
+    return bcc;
+  }
+
+  public void setBcc(List<String> bcc) {
+    this.bcc = bcc;
+  }
+
+  public List<Map<String, Object>> getAttachments() {
+    return attachments;
+  }
+
+  public void setAttachments(List<Map<String, Object>> attachments) {
+    this.attachments = attachments;
+  }
+}

--- a/server/src/main/java/com/location/server/api/v1/dto/MailSendTemplateRequest.java
+++ b/server/src/main/java/com/location/server/api/v1/dto/MailSendTemplateRequest.java
@@ -1,0 +1,84 @@
+package com.location.server.api.v1.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+
+public class MailSendTemplateRequest {
+  @Email(message = "Destinataire invalide")
+  private String to;
+
+  private List<@Email(message = "Destinataire invalide") String> toList;
+
+  @NotBlank(message = "Sujet requis")
+  @Size(max = 200, message = "Sujet trop long")
+  private String subject;
+
+  @NotBlank(message = "Clé de template requise")
+  @Size(max = 120, message = "Clé de template trop longue")
+  private String key;
+
+  private Map<String, Object> context;
+  private boolean attachPdf = true;
+
+  @Size(max = 120, message = "Nom de fichier trop long")
+  private String filename = "document.pdf";
+
+  public String getTo() {
+    return to;
+  }
+
+  public void setTo(String to) {
+    this.to = to;
+  }
+
+  public List<String> getToList() {
+    return toList;
+  }
+
+  public void setToList(List<String> toList) {
+    this.toList = toList;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public Map<String, Object> getContext() {
+    return context;
+  }
+
+  public void setContext(Map<String, Object> context) {
+    this.context = context;
+  }
+
+  public boolean isAttachPdf() {
+    return attachPdf;
+  }
+
+  public void setAttachPdf(boolean attachPdf) {
+    this.attachPdf = attachPdf;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  public void setFilename(String filename) {
+    this.filename = filename;
+  }
+}

--- a/server/src/main/java/com/location/server/service/MailService.java
+++ b/server/src/main/java/com/location/server/service/MailService.java
@@ -22,7 +22,7 @@ public class MailService {
   }
 
   public void send(
-      Object to,
+      List<String> to,
       String subject,
       String html,
       List<Map<String, Object>> attachments,
@@ -30,6 +30,9 @@ public class MailService {
       List<String> bcc,
       String from)
       throws Exception {
+    if (to == null || to.isEmpty()) {
+      throw new IllegalArgumentException("Destinataire requis");
+    }
     MimeMessage message = mailSender.createMimeMessage();
     boolean multipart = attachments != null && !attachments.isEmpty();
     MimeMessageHelper helper = new MimeMessageHelper(message, multipart, "UTF-8");
@@ -39,13 +42,7 @@ public class MailService {
       helper.setFrom(effectiveFrom);
     }
 
-    if (to instanceof String s) {
-      helper.setTo(s);
-    } else if (to instanceof List<?> list) {
-      helper.setTo(list.stream().map(Object::toString).toArray(String[]::new));
-    } else {
-      throw new IllegalArgumentException("Invalid 'to' type");
-    }
+    helper.setTo(to.toArray(String[]::new));
 
     if (cc != null && !cc.isEmpty()) {
       helper.setCc(cc.toArray(new String[0]));


### PR DESCRIPTION
## Summary
- add a controller advice that normalises validation and error responses across the API
- introduce dedicated mail request DTOs and update the mail controller/service to validate structured recipient data
- enhance the desktop client with a custom REST user-agent header and logging for previously silent failures

## Testing
- mvn -pl server test *(fails: blocked from downloading Maven Central dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dccee46afc83308fbe6f2dce438040