### PR TITLE
Ensure EDT-safe dialogs and limit mail API rate

### DIFF
--- a/client/src/main/java/com/location/client/ui/ClientsAdminFrame.java
+++ b/client/src/main/java/com/location/client/ui/ClientsAdminFrame.java
@@ -4,6 +4,7 @@ import com.location.client.core.DataSourceProvider;
 import com.location.client.core.Models;
 import com.location.client.ui.uikit.TableUtils;
 import com.location.client.ui.uikit.Toasts;
+import com.location.client.ui.uikit.Ui;
 
 import java.awt.BorderLayout;
 import java.awt.Desktop;
@@ -269,7 +270,10 @@ public class ClientsAdminFrame extends JFrame {
   private void saveClient() {
     String name = tfName.getText().trim();
     if (name.isEmpty()) {
-      JOptionPane.showMessageDialog(this, "Le nom est obligatoire", "Validation", JOptionPane.WARNING_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, "Le nom est obligatoire", "Validation", JOptionPane.WARNING_MESSAGE));
       return;
     }
     Models.Client payload =
@@ -386,8 +390,13 @@ public class ClientsAdminFrame extends JFrame {
 
   private void addContact() {
     if (current == null || current.id() == null) {
-      JOptionPane.showMessageDialog(
-          this, "Enregistrez d'abord le client", "Information", JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Enregistrez d'abord le client",
+                  "Information",
+                  JOptionPane.INFORMATION_MESSAGE));
       return;
     }
     Models.Contact edited = editContactDialog(null);
@@ -493,8 +502,13 @@ public class ClientsAdminFrame extends JFrame {
             JOptionPane.PLAIN_MESSAGE);
     if (result == JOptionPane.OK_OPTION) {
       if (fn.getText().trim().isEmpty() && ln.getText().trim().isEmpty()) {
-        JOptionPane.showMessageDialog(
-            this, "Renseignez au moins un prénom ou un nom", "Validation", JOptionPane.WARNING_MESSAGE);
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this,
+                    "Renseignez au moins un prénom ou un nom",
+                    "Validation",
+                    JOptionPane.WARNING_MESSAGE));
         return null;
       }
       return new Models.Contact(
@@ -512,7 +526,8 @@ public class ClientsAdminFrame extends JFrame {
     try {
       File tmp = File.createTempFile("clients-", ".csv");
       CsvUtil.exportClients(dsp, tmp.toPath());
-      JOptionPane.showMessageDialog(this, "Export CSV généré : " + tmp.getAbsolutePath());
+      String message = "Export CSV généré : " + tmp.getAbsolutePath();
+      Ui.ensure(() -> JOptionPane.showMessageDialog(this, message));
       if (Desktop.isDesktopSupported()) {
         try {
           Desktop.getDesktop().open(tmp.getParentFile());
@@ -521,7 +536,11 @@ public class ClientsAdminFrame extends JFrame {
         }
       }
     } catch (IOException ex) {
-      JOptionPane.showMessageDialog(this, "Erreur export : " + ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      String message = "Erreur export : " + ex.getMessage();
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
     }
   }
 
@@ -540,16 +559,23 @@ public class ClientsAdminFrame extends JFrame {
   private void mergeSelected() {
     int selectedRow = listTable.getSelectedRow();
     if (selectedRow < 0) {
-      JOptionPane.showMessageDialog(
-          this, "Sélectionnez d'abord un client", "Fusion", JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Sélectionnez d'abord un client",
+                  "Fusion",
+                  JOptionPane.INFORMATION_MESSAGE));
       return;
     }
     if (listData.size() < 2) {
-      JOptionPane.showMessageDialog(
-          this,
-          "Au moins deux clients sont nécessaires pour une fusion",
-          "Fusion",
-          JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Au moins deux clients sont nécessaires pour une fusion",
+                  "Fusion",
+                  JOptionPane.INFORMATION_MESSAGE));
       return;
     }
     int modelRow = listTable.convertRowIndexToModel(selectedRow);
@@ -558,11 +584,13 @@ public class ClientsAdminFrame extends JFrame {
     }
     Models.Client primary = listData.get(modelRow);
     if (primary.id() == null) {
-      JOptionPane.showMessageDialog(
-          this,
-          "Enregistrez le client sélectionné avant de lancer une fusion",
-          "Fusion",
-          JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Enregistrez le client sélectionné avant de lancer une fusion",
+                  "Fusion",
+                  JOptionPane.INFORMATION_MESSAGE));
       return;
     }
 
@@ -573,11 +601,13 @@ public class ClientsAdminFrame extends JFrame {
       }
     }
     if (candidates.isEmpty()) {
-      JOptionPane.showMessageDialog(
-          this,
-          "Aucun autre client disponible pour la fusion",
-          "Fusion",
-          JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Aucun autre client disponible pour la fusion",
+                  "Fusion",
+                  JOptionPane.INFORMATION_MESSAGE));
       return;
     }
 

--- a/client/src/main/java/com/location/client/ui/PlanningInspector.java
+++ b/client/src/main/java/com/location/client/ui/PlanningInspector.java
@@ -3,6 +3,7 @@ package com.location.client.ui;
 import com.location.client.core.DataSourceProvider;
 import com.location.client.core.Models;
 import com.location.client.ui.uikit.Chip;
+import com.location.client.ui.uikit.Ui;
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -158,8 +159,11 @@ public class PlanningInspector extends JPanel {
           });
       chipPanel.add(chip);
     }
-    chipPanel.revalidate();
-    chipPanel.repaint();
+    Ui.ensure(
+        () -> {
+          chipPanel.revalidate();
+          chipPanel.repaint();
+        });
   }
 
   private void loadSuggestions() {

--- a/client/src/main/java/com/location/client/ui/ResourceExplorerFrame.java
+++ b/client/src/main/java/com/location/client/ui/ResourceExplorerFrame.java
@@ -5,6 +5,8 @@ import com.location.client.core.Models;
 import com.location.client.ui.accordion.CollapsibleSection;
 import com.location.client.ui.icons.SvgIconLoader;
 import com.location.client.ui.uikit.TableUtils;
+import com.location.client.ui.uikit.Toasts;
+import com.location.client.ui.uikit.Ui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -46,7 +48,6 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
-import com.location.client.ui.uikit.Toasts;
 
 public class ResourceExplorerFrame extends JFrame {
   private final DataSourceProvider dataSourceProvider;
@@ -174,10 +175,13 @@ public class ResourceExplorerFrame extends JFrame {
       accordion.add(section);
     }
     accordion.add(javax.swing.Box.createVerticalGlue());
-    accordion.revalidate();
-    accordion.repaint();
-    detailPanel.revalidate();
-    detailPanel.repaint();
+    Ui.ensure(
+        () -> {
+          accordion.revalidate();
+          accordion.repaint();
+          detailPanel.revalidate();
+          detailPanel.repaint();
+        });
   }
 
   private Models.ResourceType findTypeByName(String name) {
@@ -533,12 +537,20 @@ public class ResourceExplorerFrame extends JFrame {
         start = parseDateTime(startRaw);
         end = parseDateTime(endRaw);
       } catch (DateTimeParseException ex) {
-        JOptionPane.showMessageDialog(this, "Format de date invalide", "Erreur", JOptionPane.ERROR_MESSAGE);
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this, "Format de date invalide", "Erreur", JOptionPane.ERROR_MESSAGE));
         return;
       }
       if (!end.isAfter(start)) {
-        JOptionPane.showMessageDialog(
-            this, "La date de fin doit être postérieure au début", "Erreur", JOptionPane.ERROR_MESSAGE);
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this,
+                    "La date de fin doit être postérieure au début",
+                    "Erreur",
+                    JOptionPane.ERROR_MESSAGE));
         return;
       }
       String reason =
@@ -554,7 +566,11 @@ public class ResourceExplorerFrame extends JFrame {
         loadUnavailabilities();
         Toasts.success(SwingUtilities.getWindowAncestor(this), "Indisponibilité ajoutée");
       } catch (RuntimeException ex) {
-        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+        String message = ex.getMessage();
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
       }
     }
 
@@ -574,7 +590,11 @@ public class ResourceExplorerFrame extends JFrame {
         loadUnavailabilities();
         Toasts.info(SwingUtilities.getWindowAncestor(this), "Indisponibilité supprimée");
       } catch (RuntimeException ex) {
-        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+        String message = ex.getMessage();
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
       }
     }
 
@@ -603,7 +623,10 @@ public class ResourceExplorerFrame extends JFrame {
     private void save() {
       String name = tfName.getText().trim();
       if (name.isEmpty()) {
-        JOptionPane.showMessageDialog(this, "Nom obligatoire", "Validation", JOptionPane.WARNING_MESSAGE);
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this, "Nom obligatoire", "Validation", JOptionPane.WARNING_MESSAGE));
         return;
       }
       String plate = tfPlate.getText().trim();
@@ -619,8 +642,10 @@ public class ResourceExplorerFrame extends JFrame {
           try {
             rateValue = Double.parseDouble(rateRaw);
           } catch (NumberFormatException ex) {
-            JOptionPane.showMessageDialog(
-                this, "Prix invalide", "Validation", JOptionPane.WARNING_MESSAGE);
+            Ui.ensure(
+                () ->
+                    JOptionPane.showMessageDialog(
+                        this, "Prix invalide", "Validation", JOptionPane.WARNING_MESSAGE));
             return;
           }
         }
@@ -650,9 +675,17 @@ public class ResourceExplorerFrame extends JFrame {
           callback.accept(resource);
         }
       } catch (UnsupportedOperationException ex) {
-        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+        String message = ex.getMessage();
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
       } catch (RuntimeException ex) {
-        JOptionPane.showMessageDialog(this, ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+        String message = ex.getMessage();
+        Ui.ensure(
+            () ->
+                JOptionPane.showMessageDialog(
+                    this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
       }
     }
   }

--- a/client/src/main/java/com/location/client/ui/TemplatesEditorFrame.java
+++ b/client/src/main/java/com/location/client/ui/TemplatesEditorFrame.java
@@ -3,6 +3,7 @@ package com.location.client.ui;
 import com.location.client.core.DataSourceProvider;
 import com.location.client.core.Models;
 import com.location.client.ui.uikit.MailFavorites;
+import com.location.client.ui.uikit.Ui;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -161,11 +162,11 @@ public class TemplatesEditorFrame extends JFrame {
     try {
       templates = dsp.listTemplates();
     } catch (Exception ex) {
-      JOptionPane.showMessageDialog(
-          this,
-          "Impossible de charger les templates : " + ex.getMessage(),
-          "Erreur",
-          JOptionPane.ERROR_MESSAGE);
+      String message = "Impossible de charger les templates : " + ex.getMessage();
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
       templates = List.of();
     }
     templates =
@@ -215,7 +216,7 @@ public class TemplatesEditorFrame extends JFrame {
         keyField.setText("");
         kindCombo.setSelectedIndex(0);
         editor.setText("");
-        preview.setText("");
+        Ui.ensure(() -> preview.setText(""));
       } else {
         currentKey = selected.key();
         keyField.setText(selected.key());
@@ -236,8 +237,10 @@ public class TemplatesEditorFrame extends JFrame {
   private void doSave() {
     String key = keyField.getText().trim();
     if (key.isBlank()) {
-      JOptionPane.showMessageDialog(
-          this, "La clé du template est requise.", "Templates", JOptionPane.WARNING_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, "La clé du template est requise.", "Templates", JOptionPane.WARNING_MESSAGE));
       keyField.requestFocusInWindow();
       return;
     }
@@ -253,11 +256,19 @@ public class TemplatesEditorFrame extends JFrame {
       currentTemplate = saved;
       currentKey = saved.key();
       refreshList(saved.id());
-      JOptionPane.showMessageDialog(
-          this, "Template enregistré.", "Templates", JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Template enregistré.",
+                  "Templates",
+                  JOptionPane.INFORMATION_MESSAGE));
     } catch (Exception ex) {
-      JOptionPane.showMessageDialog(
-          this, "Erreur lors de l'enregistrement : " + ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      String message = "Erreur lors de l'enregistrement : " + ex.getMessage();
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
     }
   }
 
@@ -270,8 +281,11 @@ public class TemplatesEditorFrame extends JFrame {
       html = "";
     }
     String merged = applySampleContext(html);
-    preview.setText(merged);
-    preview.setCaretPosition(0);
+    Ui.ensure(
+        () -> {
+          preview.setText(merged);
+          preview.setCaretPosition(0);
+        });
   }
 
   private String applySampleContext(String template) {
@@ -310,11 +324,19 @@ public class TemplatesEditorFrame extends JFrame {
       if (choice.remember()) {
         MailFavorites.add(choice.email());
       }
-      JOptionPane.showMessageDialog(
-          this, "Email (test) envoyé (stub).", "Email", JOptionPane.INFORMATION_MESSAGE);
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this,
+                  "Email (test) envoyé (stub).",
+                  "Email",
+                  JOptionPane.INFORMATION_MESSAGE));
     } catch (Exception ex) {
-      JOptionPane.showMessageDialog(
-          this, "Envoi impossible : " + ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      String message = "Envoi impossible : " + ex.getMessage();
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
     }
   }
 
@@ -325,7 +347,7 @@ public class TemplatesEditorFrame extends JFrame {
     keyField.setText("");
     kindCombo.setSelectedIndex(0);
     editor.setText("");
-    preview.setText("");
+    Ui.ensure(() -> preview.setText(""));
     keyField.requestFocusInWindow();
   }
 
@@ -351,8 +373,11 @@ public class TemplatesEditorFrame extends JFrame {
       refreshList(null);
       newTemplate();
     } catch (Exception ex) {
-      JOptionPane.showMessageDialog(
-          this, "Suppression impossible : " + ex.getMessage(), "Erreur", JOptionPane.ERROR_MESSAGE);
+      String message = "Suppression impossible : " + ex.getMessage();
+      Ui.ensure(
+          () ->
+              JOptionPane.showMessageDialog(
+                  this, message, "Erreur", JOptionPane.ERROR_MESSAGE));
     }
   }
 

--- a/client/src/main/java/com/location/client/ui/uikit/Ui.java
+++ b/client/src/main/java/com/location/client/ui/uikit/Ui.java
@@ -1,0 +1,28 @@
+package com.location.client.ui.uikit;
+
+import javax.swing.SwingUtilities;
+
+/** Small helpers to enforce Swing EDT discipline. */
+public final class Ui {
+  private Ui() {}
+
+  /** Run later on the EDT. Safe to call from any thread. */
+  public static void later(Runnable runnable) {
+    if (runnable == null) {
+      return;
+    }
+    SwingUtilities.invokeLater(runnable);
+  }
+
+  /** Run immediately if already on the EDT, otherwise schedule later. */
+  public static void ensure(Runnable runnable) {
+    if (runnable == null) {
+      return;
+    }
+    if (SwingUtilities.isEventDispatchThread()) {
+      runnable.run();
+    } else {
+      SwingUtilities.invokeLater(runnable);
+    }
+  }
+}

--- a/server/src/main/java/com/location/server/api/RateLimitFilter.java
+++ b/server/src/main/java/com/location/server/api/RateLimitFilter.java
@@ -1,0 +1,54 @@
+package com.location.server.api;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/** Tiny per-IP rate limiter for /api/v1/mail/* to avoid abuse. */
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+  private static final Map<String, AtomicInteger> COUNTS = new ConcurrentHashMap<>();
+  private static final Map<String, Long> WINDOWS = new ConcurrentHashMap<>();
+  private static final int LIMIT = 20; // 20 req / 60s
+  private static final long WINDOW_MS = 60_000L;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    return path == null || !path.startsWith("/api/v1/mail/");
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String ip = request.getRemoteAddr();
+    long now = System.currentTimeMillis();
+    long windowStart = WINDOWS.getOrDefault(ip, 0L);
+    AtomicInteger counter = COUNTS.computeIfAbsent(ip, key -> new AtomicInteger());
+    if (now - windowStart > WINDOW_MS) {
+      WINDOWS.put(ip, now);
+      counter.set(0);
+      windowStart = now;
+    }
+    int current = counter.incrementAndGet();
+    if (current > LIMIT) {
+      long retryInSeconds = Math.max(1L, (WINDOW_MS - (now - windowStart)) / 1000L);
+      response.setStatus(HttpServletResponse.SC_TOO_MANY_REQUESTS);
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response
+          .getWriter()
+          .write("{\"error\":\"rate_limited\",\"retry_in\":\"" + retryInSeconds + "s\"}");
+      return;
+    }
+    filterChain.doFilter(request, response);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable Ui helper to ensure EDT-safe Swing updates
- update multiple client frames to show dialogs and refresh UI on the EDT
- introduce a rate limiting filter around the /api/v1/mail endpoints on the server

## Testing
- mvn -DskipTests compile *(fails: non-resolvable import POM from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd17e0d048330a07b597a23e1a32e