### PR TITLE
Add circuit breaker and UI notification for REST network failures

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -7,8 +7,10 @@ import com.location.client.core.RestDataSource;
 import com.location.client.ui.i18n.Language;
 import com.location.client.ui.uikit.EmptyState;
 import com.location.client.ui.uikit.Icons;
+import com.location.client.ui.uikit.Notify;
 import com.location.client.ui.uikit.Svg;
 import com.location.client.ui.uikit.Toasts;
+import com.location.client.ui.uikit.Ui;
 import java.awt.BorderLayout;
 import java.awt.Desktop;
 import java.awt.Dimension;
@@ -73,6 +75,10 @@ public class MainFrame extends JFrame {
 
   public MainFrame(DataSourceProvider dsp, Preferences prefs) {
     super("LOCATION — Planning");
+
+    final java.beans.PropertyChangeListener networkListener =
+        evt -> Ui.ensure(() -> Toasts.error(MainFrame.this, String.valueOf(evt.getNewValue())));
+    Notify.on("network.error", networkListener);
     this.dsp = dsp;
     this.prefs = prefs;
     ResourceColors.initialize(prefs);
@@ -128,6 +134,7 @@ public class MainFrame extends JFrame {
             if (badgeTimer != null) {
               badgeTimer.stop();
             }
+            Notify.off("network.error", networkListener);
             try {
               dsp.close();
             } catch (Exception ignored) {

--- a/client/src/main/java/com/location/client/ui/uikit/Log.java
+++ b/client/src/main/java/com/location/client/ui/uikit/Log.java
@@ -1,0 +1,29 @@
+package com.location.client.ui.uikit;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Tiny logger facade over java.util.logging. */
+public final class Log {
+  private final Logger logger;
+
+  private Log(Class<?> cls) {
+    this.logger = Logger.getLogger(cls.getName());
+  }
+
+  public static Log get(Class<?> cls) {
+    return new Log(cls);
+  }
+
+  public void info(String msg) {
+    logger.log(Level.INFO, msg);
+  }
+
+  public void warn(String msg) {
+    logger.log(Level.WARNING, msg);
+  }
+
+  public void error(String msg, Throwable t) {
+    logger.log(Level.SEVERE, msg, t);
+  }
+}

--- a/client/src/main/java/com/location/client/ui/uikit/Notify.java
+++ b/client/src/main/java/com/location/client/ui/uikit/Notify.java
@@ -1,0 +1,23 @@
+package com.location.client.ui.uikit;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+/** Super simple app-wide notification bus (thread-safe). */
+public final class Notify {
+  private static final PropertyChangeSupport SUPPORT = new PropertyChangeSupport(Notify.class);
+
+  private Notify() {}
+
+  public static void on(String event, PropertyChangeListener listener) {
+    SUPPORT.addPropertyChangeListener(event, listener);
+  }
+
+  public static void off(String event, PropertyChangeListener listener) {
+    SUPPORT.removePropertyChangeListener(event, listener);
+  }
+
+  public static void post(String event, Object payload) {
+    SUPPORT.firePropertyChange(event, null, payload);
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight `Log` and `Notify` utilities for shared UI messaging
- integrate a circuit breaker style retry policy in `RestDataSource` that logs and broadcasts network failures
- subscribe the Swing main frame to network error notifications and surface toast feedback to the user

## Testing
- mvn -pl client test *(fails: Maven Central returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd3135ffc83309a465ab4c79ccf9b