### PR TITLE
Add conflicts view to planning sidebar

### DIFF
--- a/client/src/main/java/com/location/client/ui/ConflictsPanel.java
+++ b/client/src/main/java/com/location/client/ui/ConflictsPanel.java
@@ -1,0 +1,87 @@
+package com.location.client.ui;
+
+import com.location.client.core.Models;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import javax.swing.DefaultListModel;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListCellRenderer;
+
+public class ConflictsPanel extends JPanel {
+  private final DefaultListModel<ConflictRow> model = new DefaultListModel<>();
+  private final JList<ConflictRow> list = new JList<>(model);
+  private final JCheckBox onlyVisible = new JCheckBox("Ressources visibles", true);
+  private final JCheckBox onlySelectedDay = new JCheckBox("Jour courant", false);
+
+  public ConflictsPanel() {
+    super(new BorderLayout(6, 6));
+    list.setCellRenderer(new Renderer());
+    add(new JScrollPane(list), BorderLayout.CENTER);
+    JPanel north = new JPanel(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT));
+    north.add(new JLabel("Conflits"));
+    north.add(onlyVisible);
+    north.add(onlySelectedDay);
+    add(north, BorderLayout.NORTH);
+  }
+
+  public void setConflicts(List<ConflictUtil.Conflict> conflicts) {
+    model.clear();
+    if (conflicts == null) {
+      return;
+    }
+    for (ConflictUtil.Conflict c : conflicts) {
+      model.addElement(new ConflictRow(c));
+    }
+  }
+
+  private static class ConflictRow {
+    final ConflictUtil.Conflict conflict;
+
+    ConflictRow(ConflictUtil.Conflict c) {
+      this.conflict = c;
+    }
+  }
+
+  private static class Renderer extends JLabel implements ListCellRenderer<ConflictRow> {
+    private final DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM HH:mm");
+
+    @Override
+    public Component getListCellRendererComponent(
+        JList<? extends ConflictRow> list,
+        ConflictRow value,
+        int index,
+        boolean isSelected,
+        boolean cellHasFocus) {
+      setOpaque(true);
+      if (value == null) {
+        setText("");
+        return this;
+      }
+      Models.Intervention a = value.conflict.a();
+      Models.Intervention b = value.conflict.b();
+      String who =
+          (a.clientName() != null ? a.clientName() : "?")
+              + " ↔ "
+              + (b.clientName() != null ? b.clientName() : "?");
+      String when = "";
+      if (a.start() != null && a.end() != null) {
+        when = fmt.format(a.start()) + "–" + fmt.format(a.end());
+      }
+      setText("<html><b>" + who + "</b><br/>" + when + "</html>");
+      if (isSelected) {
+        setBackground(list.getSelectionBackground());
+        setForeground(list.getSelectionForeground());
+      } else {
+        setBackground(list.getBackground());
+        setForeground(list.getForeground());
+      }
+      return this;
+    }
+  }
+}

--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -148,7 +148,32 @@ public class MainFrame extends JFrame {
     JPanel planningContainer = new JPanel(new BorderLayout());
     inspector.setPreferredSize(new Dimension(320, 600));
     planningContainer.add(planning, BorderLayout.CENTER);
-    planningContainer.add(inspector, BorderLayout.EAST);
+    JTabbedPane eastTabs = new JTabbedPane();
+    ConflictsPanel conflictsPanel = new ConflictsPanel();
+    eastTabs.addTab("Inspecteur", inspector);
+    eastTabs.addTab("Conflits", conflictsPanel);
+    planningContainer.add(eastTabs, BorderLayout.EAST);
+    java.beans.PropertyChangeListener l_conf =
+        evt -> {
+          Object v = evt.getNewValue();
+          if (v instanceof java.util.List<?> list
+              && (list.isEmpty() || list.get(0) instanceof ConflictUtil.Conflict)) {
+            conflictsPanel.setConflicts((java.util.List<ConflictUtil.Conflict>) v);
+            eastTabs.setTitleAt(
+                1, list.isEmpty() ? "Conflits" : "Conflits (" + list.size() + ")");
+          } else if (v == null) {
+            conflictsPanel.setConflicts(null);
+            eastTabs.setTitleAt(1, "Conflits");
+          }
+        };
+    Notify.on("conflicts.update", l_conf);
+    this.addWindowListener(
+        new java.awt.event.WindowAdapter() {
+          @Override
+          public void windowClosed(java.awt.event.WindowEvent e) {
+            Notify.off("conflicts.update", l_conf);
+          }
+        });
     planningContainer.add(minimap, BorderLayout.SOUTH);
 
     centerCards.add(planningContainer, "planning");


### PR DESCRIPTION
## Summary
- add a dedicated `ConflictsPanel` that lists conflicting interventions
- wrap the inspector area in a tabbed pane with a new "Conflits" tab and live count
- subscribe to conflict updates and clean up the listener on window close

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcd4ed4958833095c10a3c0d596a99