### PR TITLE
Improve ghost drag feedback while moving tiles

### DIFF
--- a/client/src/main/java/com/location/client/ui/PlanningPanel.java
+++ b/client/src/main/java/com/location/client/ui/PlanningPanel.java
@@ -1754,6 +1754,11 @@ public class PlanningPanel extends JPanel {
     int nx1 = Math.max(minX, Math.min(tile.x1, maxX));
     int nx2 = Math.max(minX, Math.min(tile.x2, maxX));
     dragTile = new Tile(tile.i, tile.row, nx1, nx2, tile.alpha);
+    // Update ghost rectangle for visual feedback
+    Rectangle r =
+        new Rectangle(
+            Math.min(nx1, nx2), rowY(dragTile.row), Math.abs(nx2 - nx1), rowH(dragTile.row));
+    setGhostDrag(r);
     repaint();
   }
 
@@ -1767,6 +1772,7 @@ public class PlanningPanel extends JPanel {
     Tile finalTile = dragTile;
     dragTile = null;
     dragStart = null;
+    clearGhostDrag();
     repaint();
     if (resources.isEmpty()) {
       return;


### PR DESCRIPTION
## Summary
- update the drag handling to refresh the ghost rectangle during movement for better feedback
- clear the ghost rectangle when the drag is released

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd4f40f788330979f47ff16bc53af