### PR TITLE
Improve theme controls and add template icons

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -740,6 +740,7 @@ public class MainFrame extends JFrame {
     view.add(viewActivity);
     view.addSeparator();
     view.add(bookmarksMenu);
+    com.location.client.ui.uikit.Theme.attach(view, this);
 
     JMenu settings = new JMenu(Language.tr("menu.settings"));
     settings.setMnemonic(Language.isEnglish() ? 'S' : 'P');
@@ -747,22 +748,6 @@ public class MainFrame extends JFrame {
     switchSrc.addActionListener(e -> switchSource());
     JMenuItem cfg = new JMenuItem("Configurer le backend (URL/Login)");
     cfg.addActionListener(e -> showBackendConfig());
-    JMenuItem themeLight =
-        new JMenuItem(
-            new AbstractAction("Thème clair (Ctrl+Alt+L)") {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                Theme.apply(Theme.Mode.LIGHT);
-              }
-            });
-    JMenuItem themeDark =
-        new JMenuItem(
-            new AbstractAction("Thème sombre (Ctrl+Alt+D)") {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                Theme.apply(Theme.Mode.DARK);
-              }
-            });
     JMenuItem tmpl = new JMenuItem("Modèle email (Agence)");
     tmpl.addActionListener(e -> editAgencyTemplate());
     JMenuItem loginItem =
@@ -799,33 +784,6 @@ public class MainFrame extends JFrame {
             });
     settings.add(switchSrc);
     settings.add(cfg);
-    settings.add(themeLight);
-    settings.add(themeDark);
-    settings.addSeparator();
-    settings.add(
-        new JMenuItem(
-            new AbstractAction(Language.tr("font.increase")) {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                Theme.setFontScale(Theme.getFontScale() + 0.1f);
-              }
-            }));
-    settings.add(
-        new JMenuItem(
-            new AbstractAction(Language.tr("font.decrease")) {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                Theme.setFontScale(Theme.getFontScale() - 0.1f);
-              }
-            }));
-    settings.add(
-        new JMenuItem(
-            new AbstractAction(Language.tr("font.reset")) {
-              @Override
-              public void actionPerformed(ActionEvent e) {
-                Theme.setFontScale(1.0f);
-              }
-            }));
     JCheckBoxMenuItem highContrastItem = new JCheckBoxMenuItem(Language.tr("contrast.toggle"), Theme.isHighContrast());
     highContrastItem.addActionListener(e -> Theme.setHighContrast(highContrastItem.isSelected()));
     settings.add(highContrastItem);

--- a/client/src/main/java/com/location/client/ui/TemplatesEditorFrame.java
+++ b/client/src/main/java/com/location/client/ui/TemplatesEditorFrame.java
@@ -2,6 +2,7 @@ package com.location.client.ui;
 
 import com.location.client.core.DataSourceProvider;
 import com.location.client.core.Models;
+import com.location.client.ui.uikit.Icons;
 import com.location.client.ui.uikit.MailFavorites;
 import com.location.client.ui.uikit.Ui;
 import java.awt.BorderLayout;
@@ -66,8 +67,8 @@ public class TemplatesEditorFrame extends JFrame {
     top.add(new JLabel("Clé:"));
     keyField.setColumns(14);
     top.add(keyField);
-    JButton save = new JButton("Enregistrer");
-    JButton render = new JButton("Prévisualiser");
+    JButton save = new JButton("Enregistrer", Icons.of("save", 16));
+    JButton render = new JButton("Prévisualiser", Icons.of("preview", 16));
     JButton sendTest = new JButton("Envoyer test...");
     JButton insertVar = new JButton("Insérer variable");
     JButton btNew = new JButton("Nouveau");

--- a/client/src/main/java/com/location/client/ui/uikit/Icons.java
+++ b/client/src/main/java/com/location/client/ui/uikit/Icons.java
@@ -1,15 +1,34 @@
 package com.location.client.ui.uikit;
 
-public interface Icons {
-  String CALENDAR = "calendar-event";
-  String FILE_TEXT = "file-text";
-  String PDF = "file-type-pdf";
-  String SEND = "send";
-  String CLIENTS = "users";
-  String RESOURCES = "boxes";
-  String DRIVERS = "truck";
-  String CONFLICT = "alert-octagon";
-  String CHECK = "check-circle";
-  String SEARCH = "search";
-  String SETTINGS = "settings";
+import com.formdev.flatlaf.extras.FlatSVGIcon;
+import javax.swing.Icon;
+import javax.swing.UIManager;
+
+public final class Icons {
+  public static final String CALENDAR = "calendar-event";
+  public static final String FILE_TEXT = "file-text";
+  public static final String PDF = "file-type-pdf";
+  public static final String SEND = "send";
+  public static final String CLIENTS = "users";
+  public static final String RESOURCES = "boxes";
+  public static final String DRIVERS = "truck";
+  public static final String CONFLICT = "alert-octagon";
+  public static final String CHECK = "check-circle";
+  public static final String SEARCH = "search";
+  public static final String SETTINGS = "settings";
+
+  private Icons() {}
+
+  public static Icon of(String name, int size) {
+    try {
+      return new FlatSVGIcon("icons/" + name + ".svg", size, size);
+    } catch (Exception ex) {
+      Icon fallback = Svg.icon(name, size);
+      if (fallback != null) {
+        return fallback;
+      }
+      Icon fileIcon = UIManager.getIcon("FileView.fileIcon");
+      return fileIcon != null ? fileIcon : new Svg.EmptyIcon(size, size);
+    }
+  }
 }

--- a/client/src/main/resources/icons/calendar.svg
+++ b/client/src/main/resources/icons/calendar.svg
@@ -1,9 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <rect x="3" y="4" width="18" height="17" rx="2" ry="2" fill="#888"/>
-  <rect x="3" y="8" width="18" height="13" fill="#fff"/>
-  <rect x="6" y="11" width="3" height="3" fill="#888"/>
-  <rect x="11" y="11" width="3" height="3" fill="#888"/>
-  <rect x="16" y="11" width="3" height="3" fill="#888"/>
-  <rect x="6" y="16" width="3" height="3" fill="#888"/>
-  <rect x="11" y="16" width="3" height="3" fill="#888"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2" fill="none" stroke="currentColor"/><path d="M3 10h18" stroke="currentColor"/></svg>

--- a/client/src/main/resources/icons/conflict.svg
+++ b/client/src/main/resources/icons/conflict.svg
@@ -1,6 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" fill="none"/>
-  <path d="M32 6 L58 54 H6 Z" fill="#ef5350"/>
-  <rect x="30" y="24" width="4" height="18" fill="#fff"/>
-  <rect x="30" y="46" width="4" height="4" fill="#fff"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="currentColor" opacity=".15"/><path fill="currentColor" d="M11 6h2v7h-2zM11 15h2v3h-2z"/></svg>

--- a/client/src/main/resources/icons/duplicate.svg
+++ b/client/src/main/resources/icons/duplicate.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M8 8h12v12H8z"/><path fill="currentColor" d="M4 4h12v12H4z" opacity=".5"/></svg>

--- a/client/src/main/resources/icons/preview.svg
+++ b/client/src/main/resources/icons/preview.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 5c-7 0-10 7-10 7s3 7 10 7 10-7 10-7-3-7-10-7zm0 11a4 4 0 110-8 4 4 0 010 8z"/></svg>

--- a/client/src/main/resources/icons/save.svg
+++ b/client/src/main/resources/icons/save.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M17 3H5a2 2 0 0 0-2 2v14l4-4h10a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z"/></svg>

--- a/client/src/main/resources/icons/search.svg
+++ b/client/src/main/resources/icons/search.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 21l-4.35-4.35 M10 18a8 8 0 1 1 0-16 8 8 0 0 1 0 16z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7" stroke="currentColor" fill="none"/><path d="M16 16l5 5" stroke="currentColor"/></svg>

--- a/client/src/main/resources/icons/send.svg
+++ b/client/src/main/resources/icons/send.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 2L11 13 M22 2l-7 20-4-9-9-4 20-7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M2 21l21-9L2 3v7l15 2-15 2z"/></svg>


### PR DESCRIPTION
## Summary
- add a reusable theme helper that injects light/dark toggles and UI scale controls into the View menu
- convert the icon constants container into a utility class and use new save/preview glyphs in the templates editor
- refresh several SVG assets to the new monochrome style used across the application

## Testing
- `mvn -pl client -am -DskipTests compile` *(fails: Maven Central returned 403 while resolving spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdd95e50c83309f2163596a778365