### PR TITLE
Add planning toolbar and theme helpers

### DIFF
--- a/client/src/main/java/com/location/client/ui/MainFrame.java
+++ b/client/src/main/java/com/location/client/ui/MainFrame.java
@@ -6,6 +6,7 @@ import com.location.client.core.Models;
 import com.location.client.core.Preferences;
 import com.location.client.core.RestDataSource;
 import com.location.client.ui.i18n.Language;
+import com.location.client.ui.PlanningToolbar;
 import com.location.client.ui.uikit.EmptyState;
 import com.location.client.ui.uikit.Icons;
 import com.location.client.ui.uikit.Notify;
@@ -159,6 +160,7 @@ public class MainFrame extends JFrame {
     add(sidebar, BorderLayout.WEST);
     JPanel planningContainer = new JPanel(new BorderLayout());
     inspector.setPreferredSize(new Dimension(320, 600));
+    planningContainer.add(new PlanningToolbar(planning), BorderLayout.NORTH);
     planningContainer.add(planning, BorderLayout.CENTER);
     JTabbedPane eastTabs = new JTabbedPane();
     ConflictsPanel conflictsPanel = new ConflictsPanel();

--- a/client/src/main/java/com/location/client/ui/PlanningToolbar.java
+++ b/client/src/main/java/com/location/client/ui/PlanningToolbar.java
@@ -1,0 +1,67 @@
+package com.location.client.ui;
+
+import com.location.client.ui.uikit.Icons;
+import com.location.client.ui.uikit.Theme;
+import com.location.client.ui.uikit.ThemeFonts;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+
+public class PlanningToolbar extends JToolBar {
+  private final PlanningPanel planning;
+
+  public PlanningToolbar(PlanningPanel planning){
+    super("Outils");
+    this.planning = planning;
+    setFloatable(false);
+    setBorder(BorderFactory.createEmptyBorder(4,6,4,6));
+    build();
+  }
+
+  private void build(){
+    add(action("Annuler", Icons.of("undo", 18), e -> planning.undoLast()));
+    add(action("Rétablir", Icons.of("redo", 18), e -> planning.redoLast()));
+    addSeparator();
+
+    add(action("Dupliquer +1j", Icons.of("duplicate", 18), e -> planning.duplicateSelected(1)));
+    add(action("Dupliquer +7j", Icons.of("calendar", 18), e -> planning.duplicateSelected(7)));
+    addSeparator();
+
+    add(action("Vue jour", Icons.of("day", 18), e -> planning.setWeekMode(false)));
+    add(action("Vue semaine", Icons.of("week", 18), e -> planning.setWeekMode(true)));
+    addSeparator();
+
+    JTextField tagQuick = new JTextField(14);
+    tagQuick.putClientProperty("JTextField.placeholderText", "Ajouter tag rapide…");
+    tagQuick.addActionListener(ev -> {
+      String t = tagQuick.getText().trim();
+      if (!t.isEmpty()) planning.addQuickTagToSelection(t);
+      tagQuick.setText("");
+    });
+    add(new JLabel(Icons.of("tag", 16)));
+    add(tagQuick);
+    addSeparator();
+
+    add(action("Thème", Icons.of("palette", 18), e -> Theme.apply(nextMode(), getScale(), true)));
+    add(action("Taille police", Icons.of("font", 18), e -> {
+      ThemeFonts.applyDefaultFont();
+      SwingUtilities.updateComponentTreeUI(SwingUtilities.getWindowAncestor(this));
+    }));
+  }
+
+  private Action action(String name, Icon icon, java.util.function.Consumer<ActionEvent> cb){
+    return new AbstractAction(name, icon){
+      @Override public void actionPerformed(ActionEvent e){ cb.accept(e); }
+    };
+  }
+
+  private String nextMode(){
+    return com.location.client.ui.Theme.currentMode() == com.location.client.ui.Theme.Mode.LIGHT
+        ? "dark"
+        : "light";
+  }
+
+  private float getScale(){
+    return com.location.client.ui.Theme.getFontScale();
+  }
+}

--- a/client/src/main/java/com/location/client/ui/Theme.java
+++ b/client/src/main/java/com/location/client/ui/Theme.java
@@ -4,6 +4,8 @@ import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatLightLaf;
 import com.location.client.core.Preferences;
+import com.location.client.ui.uikit.ThemeFonts;
+import com.location.client.ui.uikit.ThemePalette;
 import java.awt.Font;
 import java.awt.Window;
 import java.util.Enumeration;
@@ -51,9 +53,7 @@ public final class Theme {
       } else {
         UIManager.setLookAndFeel(new FlatLightLaf());
       }
-      installDefaults();
-      applyHighContrastDefaults();
-      resetFontDefaults();
+      applyUiDefaults();
       current = mode;
       if (persist && preferences != null) {
         preferences.setThemeMode(mode.name());
@@ -61,8 +61,7 @@ public final class Theme {
       }
       if (updateUI) {
         FlatLaf.updateUI();
-        applyHighContrastDefaults();
-        resetFontDefaults();
+        applyUiDefaults();
         for (Window window : Window.getWindows()) {
           SwingUtilities.updateComponentTreeUI(window);
         }
@@ -96,12 +95,18 @@ public final class Theme {
     }
   }
 
+  private static void applyUiDefaults() {
+    installDefaults();
+    ThemePalette.apply("#3D7EFF");
+    ThemeFonts.applyDefaultFont();
+    applyHighContrastDefaults();
+    resetFontDefaults();
+  }
+
   public static void installDefaults() {
-    UIManager.put("Component.arc", 12);
-    UIManager.put("Button.arc", 16);
-    UIManager.put("TextComponent.arc", 12);
     UIManager.put("ScrollBar.width", 14);
     UIManager.put("TitlePane.unifiedBackground", true);
+    UIManager.put("TitlePane.menuBarEmbedded", true);
   }
 
   private static void applyHighContrastDefaults() {

--- a/client/src/main/java/com/location/client/ui/uikit/Theme.java
+++ b/client/src/main/java/com/location/client/ui/uikit/Theme.java
@@ -74,6 +74,30 @@ public final class Theme {
     view.add(reset);
   }
 
+  public static void apply(String mode, float scale, boolean animate) {
+    Runnable task = () -> {
+      if (Math.abs(scale - com.location.client.ui.Theme.getFontScale()) > 0.001f) {
+        com.location.client.ui.Theme.setFontScale(scale);
+      }
+      com.location.client.ui.Theme.apply(parseMode(mode));
+    };
+    if (animate) {
+      animate(task);
+    } else {
+      task.run();
+    }
+  }
+
+  private static com.location.client.ui.Theme.Mode parseMode(String mode) {
+    if (mode == null) {
+      return com.location.client.ui.Theme.Mode.LIGHT;
+    }
+    return switch (mode.toLowerCase()) {
+      case "dark" -> com.location.client.ui.Theme.Mode.DARK;
+      default -> com.location.client.ui.Theme.Mode.LIGHT;
+    };
+  }
+
   private static void apply(JFrame frame, com.location.client.ui.Theme.Mode mode) {
     animate(() -> com.location.client.ui.Theme.apply(mode));
   }

--- a/client/src/main/java/com/location/client/ui/uikit/ThemeFonts.java
+++ b/client/src/main/java/com/location/client/ui/uikit/ThemeFonts.java
@@ -1,0 +1,30 @@
+package com.location.client.ui.uikit;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.InputStream;
+
+public final class ThemeFonts {
+  private ThemeFonts(){}
+
+  public static void applyDefaultFont() {
+    Font base = tryLoad("/fonts/Inter-Regular.ttf");
+    if (base == null) base = tryLoad("/fonts/Roboto-Regular.ttf");
+    if (base == null) base = new Font("SansSerif", Font.PLAIN, 13);
+    final Font f = base.deriveFont(13f);
+    UIManager.getLookAndFeelDefaults().forEach((k, v) -> {
+      if (v instanceof Font) UIManager.put(k, f);
+    });
+  }
+
+  private static Font tryLoad(String res){
+    try (InputStream in = ThemeFonts.class.getResourceAsStream(res)){
+      if (in == null) return null;
+      Font f = Font.createFont(Font.TRUETYPE_FONT, in);
+      GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(f);
+      return f;
+    } catch (Exception ignore){
+      return null;
+    }
+  }
+}

--- a/client/src/main/java/com/location/client/ui/uikit/ThemePalette.java
+++ b/client/src/main/java/com/location/client/ui/uikit/ThemePalette.java
@@ -1,0 +1,40 @@
+package com.location.client.ui.uikit;
+
+import javax.swing.*;
+import java.awt.*;
+
+public final class ThemePalette {
+  private ThemePalette(){}
+
+  public static void apply(String accentHex){
+    Color accent = parseColor(accentHex, new Color(0,120,215));
+    UIManager.put("Component.arc", 16);
+    UIManager.put("Button.arc", 18);
+    UIManager.put("TextComponent.arc", 14);
+    UIManager.put("ScrollBar.thumbArc", 14);
+    UIManager.put("Component.focusWidth", 1);
+    UIManager.put("Component.innerFocusWidth", 0);
+    UIManager.put("Component.focusColor", accent);
+    UIManager.put("Button.focusedBorderColor", accent);
+    UIManager.put("CheckBox.icon.focusColor", accent);
+    UIManager.put("RadioButton.icon.focusColor", accent);
+    UIManager.put("TabbedPane.focusColor", accent);
+    UIManager.put("Button.hoverBackground", withAlpha(accent, 30));
+    UIManager.put("Button.pressedBackground", withAlpha(accent, 60));
+    UIManager.put("TextComponent.selectionBackground", withAlpha(accent, 90));
+    UIManager.put("Table.selectionBackground", withAlpha(accent, 80));
+    UIManager.put("List.selectionBackground", withAlpha(accent, 80));
+  }
+
+  private static Color parseColor(String hex, Color def){
+    try {
+      return Color.decode(hex);
+    } catch (Exception e){
+      return def;
+    }
+  }
+
+  private static Color withAlpha(Color c, int a){
+    return new Color(c.getRed(), c.getGreen(), c.getBlue(), Math.max(0, Math.min(255, a)));
+  }
+}

--- a/client/src/main/resources/icons/day.svg
+++ b/client/src/main/resources/icons/day.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke="currentColor" fill="none"/><path d="M3 10h18M8 10v10" stroke="currentColor"/></svg>

--- a/client/src/main/resources/icons/font.svg
+++ b/client/src/main/resources/icons/font.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M5 20l7-16h2l7 16h-2.5l-1.9-4.5h-7.2L7.5 20H5zm9-6l-2.5-6-2.6 6H14z"/></svg>

--- a/client/src/main/resources/icons/palette.svg
+++ b/client/src/main/resources/icons/palette.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 1 0 0 20c1.7 0 2-1 2-2 0-1 1-2 2-2h2a2 2 0 0 0 2-2 10 10 0 0 0-8-14zM7 8a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm4-3a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm4 3a2 2 0 1 1 0 4 2 2 0 0 1 0-4z"/></svg>

--- a/client/src/main/resources/icons/redo.svg
+++ b/client/src/main/resources/icons/redo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 5a7 7 0 0 0 0 14h5v-2h-5a5 5 0 0 1 0-10h6l-3-3 3-3 4 4-4 4-3-3z"/></svg>

--- a/client/src/main/resources/icons/tag.svg
+++ b/client/src/main/resources/icons/tag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path stroke="currentColor" fill="none" d="M3 12l9 9 9-9-9-9H7a4 4 0 0 0-4 4v4z"/><circle cx="9" cy="7" r="2" fill="currentColor"/></svg>

--- a/client/src/main/resources/icons/undo.svg
+++ b/client/src/main/resources/icons/undo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M12 5a7 7 0 0 1 0 14H7v-2h5a5 5 0 0 0 0-10H6l3-3-3-3L2 7l4 4 3-3z"/></svg>

--- a/client/src/main/resources/icons/week.svg
+++ b/client/src/main/resources/icons/week.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke="currentColor" fill="none"/><path d="M3 10h18M7 10v10M11 10v10M15 10v10M19 10v10" stroke="currentColor"/></svg>


### PR DESCRIPTION
## Summary
- add a dedicated planning toolbar that exposes undo/redo, duplication, view toggles, theme controls, and quick tag entry
- introduce ThemeFonts and ThemePalette utilities and hook them into the existing theme management flow
- add SVG icons that back the new toolbar affordances

## Testing
- mvn -pl client -am test *(fails: repository access blocked by HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dce345c5d08330a4d40f4875ce4433