### PR TITLE
Add agency-specific palette handling

### DIFF
--- a/client/src/main/java/com/location/client/ui/uikit/AgencyPalette.java
+++ b/client/src/main/java/com/location/client/ui/uikit/AgencyPalette.java
@@ -1,0 +1,41 @@
+package com.location.client.ui.uikit;
+
+import javax.swing.*;
+import java.util.prefs.Preferences;
+import java.util.regex.Pattern;
+
+public final class AgencyPalette {
+  private static final String PREF_NODE = "com.location.ui.agency.palette";
+  private static final Pattern HEX = Pattern.compile("^#?[0-9a-fA-F]{6}$");
+  private AgencyPalette(){}
+
+  public static void set(String agencyId, String hex){
+    if (agencyId == null || agencyId.isBlank()) return;
+    if (hex == null || !HEX.matcher(hex).matches()) return;
+    if (!hex.startsWith("#")) hex = "#"+hex;
+    prefs().put(key(agencyId), hex);
+  }
+
+  public static String get(String agencyId){
+    if (agencyId == null) return null;
+    return prefs().get(key(agencyId), null);
+  }
+
+  public static void clear(String agencyId){
+    if (agencyId == null) return;
+    prefs().remove(key(agencyId));
+  }
+
+  public static void applyForAgency(String agencyId){
+    String hex = get(agencyId);
+    if (hex == null) hex = "#3D7EFF";
+    ThemePalette.apply(hex);
+    SwingUtilities.invokeLater(() -> {
+      java.awt.Window w = javax.swing.FocusManager.getCurrentManager().getActiveWindow();
+      if (w != null) javax.swing.SwingUtilities.updateComponentTreeUI(w);
+    });
+  }
+
+  private static String key(String id){ return "accent_"+id; }
+  private static Preferences prefs(){ return Preferences.userRoot().node(PREF_NODE); }
+}

--- a/client/src/main/java/com/location/client/ui/uikit/MicroAnimations.java
+++ b/client/src/main/java/com/location/client/ui/uikit/MicroAnimations.java
@@ -2,11 +2,11 @@ package com.location.client.ui.uikit;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.*;
 
 public final class MicroAnimations {
   private MicroAnimations(){}
 
-  /** Simple pulsing border around a component. Call stop() on the returned timer to end. */
   public static Timer pulseBorder(JComponent c){
     long start = System.currentTimeMillis();
     Timer t = new Timer(40, e -> c.repaint());
@@ -16,7 +16,6 @@ public final class MicroAnimations {
     return t;
   }
 
-  /** Paint a pulse using this in component's paint after super.paint(g). */
   public static void paintPulse(JComponent c, Graphics g){
     Object v = c.getClientProperty("pulse.start");
     if (!(v instanceof Long)) return;

--- a/client/src/main/java/com/location/client/ui/uikit/ThemePalette.java
+++ b/client/src/main/java/com/location/client/ui/uikit/ThemePalette.java
@@ -8,6 +8,9 @@ public final class ThemePalette {
   public static void apply(String accentHex){
     Color accent = parse(accentHex, new Color(0,122,255));
     UIManager.put("Component.arc", 16);
+    UIManager.put("Button.arc", 18);
+    UIManager.put("TextComponent.arc", 14);
+    UIManager.put("ScrollBar.thumbArc", 14);
     UIManager.put("Component.focusColor", accent);
     UIManager.put("Button.hoverBackground", withAlpha(accent, 30));
     UIManager.put("Button.pressedBackground", withAlpha(accent, 60));


### PR DESCRIPTION
## Summary
- adjust UI component arc defaults to round buttons, inputs, and scrollbars
- add an AgencyPalette helper to persist and apply per-agency accent colors
- clean up micro animation utilities for updated palette handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcec41d1648330949bbbacf57cccd2