### PR TITLE
Support resourceIds in v1 API

### DIFF
--- a/client/src/main/java/com/location/client/ui/ConflictUtil.java
+++ b/client/src/main/java/com/location/client/ui/ConflictUtil.java
@@ -16,15 +16,19 @@ public final class ConflictUtil {
       return out;
     }
     for (int i = 0; i < interventions.size(); i++) {
-      Models.Intervention first = interventions.get(i);
+      Models.Intervention a = interventions.get(i);
       for (int j = i + 1; j < interventions.size(); j++) {
-        Models.Intervention second = interventions.get(j);
-        if (!overlap(first.start(), first.end(), second.start(), second.end())) {
+        Models.Intervention b = interventions.get(j);
+        if (!overlap(a.start(), a.end(), b.start(), b.end())) {
           continue;
         }
-        String resourceId = firstCommonResource(first, second);
-        if (resourceId != null) {
-          out.add(new Conflict(first, second, resourceId));
+        if (a.resourceIds() == null || b.resourceIds() == null) {
+          continue;
+        }
+        for (String resourceId : a.resourceIds()) {
+          if (resourceId != null && b.resourceIds().contains(resourceId)) {
+            out.add(new Conflict(a, b, resourceId));
+          }
         }
       }
     }
@@ -36,17 +40,5 @@ public final class ConflictUtil {
       return false;
     }
     return startA.isBefore(endB) && endA.isAfter(startB);
-  }
-
-  private static String firstCommonResource(Models.Intervention a, Models.Intervention b) {
-    if (a.resourceIds() == null || b.resourceIds() == null) {
-      return null;
-    }
-    for (String resourceId : a.resourceIds()) {
-      if (resourceId != null && b.resourceIds().contains(resourceId)) {
-        return resourceId;
-      }
-    }
-    return null;
   }
 }

--- a/server/src/main/java/com/location/server/api/v1/ApiV1Controller.java
+++ b/server/src/main/java/com/location/server/api/v1/ApiV1Controller.java
@@ -339,7 +339,7 @@ public class ApiV1Controller {
     return InterventionDto.of(
         interventionService.create(
             request.agencyId(),
-            request.resourceId(),
+            primaryResourceId(request.resourceIds(), request.resourceId()),
             request.driverId(),
             request.clientId(),
             request.title(),
@@ -357,7 +357,7 @@ public class ApiV1Controller {
         interventionService.update(
             id,
             request.agencyId(),
-            request.resourceId(),
+            primaryResourceId(request.resourceIds(), request.resourceId()),
             request.driverId(),
             request.clientId(),
             request.title(),
@@ -379,7 +379,10 @@ public class ApiV1Controller {
       @Valid @RequestBody CreateUnavailabilityRequest request) {
     return UnavailabilityDto.of(
         unavailabilityService.create(
-            request.resourceId(), request.start(), request.end(), request.reason()));
+            primaryResourceId(request.resourceIds(), request.resourceId()),
+            request.start(),
+            request.end(),
+            request.reason()));
   }
 
   @GetMapping("/recurring-unavailabilities")
@@ -397,11 +400,22 @@ public class ApiV1Controller {
       @Valid @RequestBody CreateRecurringUnavailabilityRequest request) {
     return RecurringUnavailabilityDto.of(
         unavailabilityService.createRecurring(
-            request.resourceId(),
+            primaryResourceId(request.resourceIds(), request.resourceId()),
             request.dayOfWeek(),
             request.start(),
             request.end(),
             request.reason()));
+  }
+
+  private static String primaryResourceId(
+      java.util.List<String> resourceIds, String legacyResourceId) {
+    if (resourceIds != null
+        && !resourceIds.isEmpty()
+        && resourceIds.get(0) != null
+        && !resourceIds.get(0).isBlank()) {
+      return resourceIds.get(0);
+    }
+    return legacyResourceId;
   }
 
   @GetMapping(value = "/interventions/{id}/pdf", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
+++ b/server/src/main/java/com/location/server/api/v1/dto/ApiV1Dtos.java
@@ -138,7 +138,8 @@ public final class ApiV1Dtos {
       OffsetDateTime end,
       String notes,
       String internalNotes,
-      Double price) {
+      Double price,
+      java.util.List<String> resourceIds) {
     public static InterventionDto of(Intervention intervention) {
       return new InterventionDto(
           intervention.getId(),
@@ -151,7 +152,8 @@ public final class ApiV1Dtos {
           intervention.getEnd(),
           intervention.getNotes(),
           intervention.getInternalNotes(),
-          intervention.getPrice());
+          intervention.getPrice(),
+          java.util.List.of(intervention.getResource().getId()));
     }
   }
 
@@ -192,6 +194,7 @@ public final class ApiV1Dtos {
   }
 
   public record CreateInterventionRequest(
+      java.util.List<String> resourceIds,
       @NotBlank String agencyId,
       @NotBlank String resourceId,
       String driverId,
@@ -204,6 +207,7 @@ public final class ApiV1Dtos {
       @DecimalMin(value = "0.0", inclusive = true) Double price) {}
 
   public record UpdateInterventionRequest(
+      java.util.List<String> resourceIds,
       @NotBlank String agencyId,
       @NotBlank String resourceId,
       String driverId,
@@ -216,12 +220,14 @@ public final class ApiV1Dtos {
       @DecimalMin(value = "0.0", inclusive = true) Double price) {}
 
   public record CreateUnavailabilityRequest(
+      java.util.List<String> resourceIds,
       @NotBlank String resourceId,
       @NotNull OffsetDateTime start,
       @NotNull OffsetDateTime end,
       @NotBlank @Size(max = 140) String reason) {}
 
   public record CreateRecurringUnavailabilityRequest(
+      java.util.List<String> resourceIds,
       @NotBlank String resourceId,
       @NotNull DayOfWeek dayOfWeek,
       @NotNull LocalTime start,


### PR DESCRIPTION
## Summary
- extend v1 DTOs and requests to expose resourceIds alongside the legacy resourceId field
- update the v1 controller to pick the primary resource from the new list while staying backward compatible
- adjust client conflict detection to compare all resourceIds instead of just the first

## Testing
- mvn -pl server test *(fails: unable to download dependencies from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf217ae9c8330b269012e1414f60c