### PR TITLE
Add resource type accordion and demo data generator

### DIFF
--- a/client/src/main/java/com/location/client/core/DataSourceProvider.java
+++ b/client/src/main/java/com/location/client/core/DataSourceProvider.java
@@ -5,7 +5,9 @@ import java.util.List;
 public interface DataSourceProvider extends AutoCloseable {
   String getLabel(); // "MOCK" or "REST"
 
-  void resetDemoData(); // no-op for REST (legacy)
+  void resetDemoData();
+
+  default void generateCurrentMonthDemo() {}
 
   default void resetDemo() {
     resetDemoData();


### PR DESCRIPTION
## Summary
- add a default hook on `DataSourceProvider` for generating current-month demo data and implement it in the mock provider
- add resource type metadata handling in the planning panel with collapsible chips and sorting by type
- adjust planning header layout to accommodate resource type filters and dynamic row positioning

## Testing
- mvn -pl client -am -DskipTests package *(fails: unable to download org.springframework.boot:spring-boot-dependencies:pom:3.3.2 due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf953c94483309f6e386305c228b5