### PR TITLE
Add client telemetry HUD and conflict metrics tracking

### DIFF
--- a/client/src/main/java/com/location/client/telemetry/EventLogDialog.java
+++ b/client/src/main/java/com/location/client/telemetry/EventLogDialog.java
@@ -1,0 +1,133 @@
+package com.location.client.telemetry;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
+/**
+ * Simple HUD to display telemetry events collected on the client.
+ */
+public final class EventLogDialog extends JDialog {
+  private static final DateTimeFormatter TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("HH:mm:ss").withLocale(Locale.ROOT);
+
+  private final Metrics metrics = Metrics.get();
+  private final JTextArea textArea = new JTextArea();
+  private Consumer<Metrics.Event> listener;
+
+  public EventLogDialog(Component parent) {
+    super(SwingUtilities.getWindowAncestor(parent), "Journal des événements", false);
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setLayout(new BorderLayout());
+    textArea.setEditable(false);
+    textArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+    textArea.setLineWrap(false);
+    add(new JScrollPane(textArea), BorderLayout.CENTER);
+
+    JPanel footer = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+    JButton clearButton = new JButton("Vider");
+    clearButton.addActionListener(
+        e -> {
+          metrics.clearEvents();
+          textArea.setText("(aucun événement)");
+        });
+    footer.add(clearButton);
+    add(footer, BorderLayout.SOUTH);
+
+    populateInitialEvents();
+    registerListener();
+
+    setSize(560, 420);
+    setLocationRelativeTo(parent);
+  }
+
+  private void populateInitialEvents() {
+    List<Metrics.Event> events = metrics.recentEvents();
+    if (events.isEmpty()) {
+      textArea.setText("(aucun événement)");
+      return;
+    }
+    StringBuilder builder = new StringBuilder();
+    for (Metrics.Event event : events) {
+      if (builder.length() > 0) {
+        builder.append(System.lineSeparator());
+      }
+      builder.append(format(event));
+    }
+    textArea.setText(builder.toString());
+    textArea.setCaretPosition(textArea.getDocument().getLength());
+  }
+
+  private void registerListener() {
+    listener =
+        event -> {
+          if (event == null) {
+            return;
+          }
+          SwingUtilities.invokeLater(
+              () -> {
+                if (textArea.getText().isBlank() || "(aucun événement)".equals(textArea.getText())) {
+                  textArea.setText("");
+                }
+                if (!textArea.getText().isEmpty()) {
+                  textArea.append(System.lineSeparator());
+                }
+                textArea.append(format(event));
+                textArea.setCaretPosition(textArea.getDocument().getLength());
+              });
+        };
+    metrics.addEventListener(listener);
+    addWindowListener(
+        new java.awt.event.WindowAdapter() {
+          @Override
+          public void windowClosed(java.awt.event.WindowEvent e) {
+            cleanup();
+          }
+
+          @Override
+          public void windowClosing(java.awt.event.WindowEvent e) {
+            cleanup();
+          }
+        });
+  }
+
+  private void cleanup() {
+    if (listener != null) {
+      metrics.removeEventListener(listener);
+      listener = null;
+    }
+  }
+
+  private String format(Metrics.Event event) {
+    String timestamp =
+        TIME_FORMATTER.format(event.getTimestamp().atZone(ZoneId.systemDefault()));
+    StringBuilder builder = new StringBuilder();
+    builder.append(timestamp).append(" · ").append(event.getType());
+    Map<String, String> attributes = event.getAttributes();
+    if (attributes != null && !attributes.isEmpty()) {
+      builder.append(" ");
+      boolean first = true;
+      for (Map.Entry<String, String> entry : attributes.entrySet()) {
+        if (!first) {
+          builder.append(", ");
+        }
+        builder.append(entry.getKey()).append("=").append(entry.getValue());
+        first = false;
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/client/src/main/java/com/location/client/telemetry/Metrics.java
+++ b/client/src/main/java/com/location/client/telemetry/Metrics.java
@@ -1,0 +1,169 @@
+package com.location.client.telemetry;
+
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * Lightweight in-memory metrics aggregator for the client runtime.
+ */
+public final class Metrics {
+  private static final Metrics INSTANCE = new Metrics();
+  private static final int MAX_EVENTS = 400;
+
+  public static Metrics get() {
+    return INSTANCE;
+  }
+
+  private final ConcurrentMap<String, AtomicLong> counters = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Stats> histograms = new ConcurrentHashMap<>();
+  private final CopyOnWriteArrayList<Consumer<Event>> listeners = new CopyOnWriteArrayList<>();
+  private final Deque<Event> events = new ArrayDeque<>();
+
+  private Metrics() {}
+
+  public long getCounter(String key) {
+    if (key == null) {
+      return 0L;
+    }
+    AtomicLong counter = counters.get(key);
+    return counter != null ? counter.get() : 0L;
+  }
+
+  public void setCounter(String key, long value) {
+    if (key == null) {
+      return;
+    }
+    counters.compute(key, (k, existing) -> {
+      if (existing == null) {
+        existing = new AtomicLong();
+      }
+      existing.set(value);
+      return existing;
+    });
+  }
+
+  public void increment(String key) {
+    increment(key, 1L);
+  }
+
+  public void increment(String key, long delta) {
+    if (key == null) {
+      return;
+    }
+    counters.computeIfAbsent(key, k -> new AtomicLong()).addAndGet(delta);
+  }
+
+  public void observe(String key, long value) {
+    if (key == null) {
+      return;
+    }
+    Stats stats = histograms.computeIfAbsent(key, k -> new Stats());
+    stats.total.addAndGet(value);
+    stats.count.incrementAndGet();
+  }
+
+  public double avgMs(String key) {
+    if (key == null) {
+      return 0d;
+    }
+    Stats stats = histograms.get(key);
+    if (stats == null) {
+      return 0d;
+    }
+    long count = stats.count.get();
+    if (count <= 0L) {
+      return 0d;
+    }
+    return stats.total.get() / (double) count;
+  }
+
+  public void event(String type, String... attributes) {
+    if (type == null || type.isBlank()) {
+      return;
+    }
+    Map<String, String> payload = new java.util.LinkedHashMap<>();
+    if (attributes != null) {
+      for (int i = 0; i + 1 < attributes.length; i += 2) {
+        String key = Objects.toString(attributes[i], "");
+        String value = Objects.toString(attributes[i + 1], "");
+        payload.put(key, value);
+      }
+    }
+    Event event = new Event(Instant.now(), type, java.util.Map.copyOf(payload));
+    synchronized (events) {
+      events.addLast(event);
+      while (events.size() > MAX_EVENTS) {
+        events.removeFirst();
+      }
+    }
+    for (Consumer<Event> listener : listeners) {
+      try {
+        listener.accept(event);
+      } catch (RuntimeException ignored) {
+      }
+    }
+  }
+
+  public List<Event> recentEvents() {
+    synchronized (events) {
+      return new ArrayList<>(events);
+    }
+  }
+
+  public void clearEvents() {
+    synchronized (events) {
+      events.clear();
+    }
+  }
+
+  public void addEventListener(Consumer<Event> listener) {
+    if (listener != null) {
+      listeners.add(listener);
+    }
+  }
+
+  public void removeEventListener(Consumer<Event> listener) {
+    if (listener != null) {
+      listeners.remove(listener);
+    }
+  }
+
+  private static final class Stats {
+    final AtomicLong total = new AtomicLong();
+    final AtomicLong count = new AtomicLong();
+  }
+
+  public static final class Event {
+    private final Instant timestamp;
+    private final String type;
+    private final Map<String, String> attributes;
+
+    Event(Instant timestamp, String type, Map<String, String> attributes) {
+      this.timestamp = timestamp;
+      this.type = type;
+      this.attributes = attributes;
+    }
+
+    public Instant getTimestamp() {
+      return timestamp;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public Map<String, String> getAttributes() {
+      return attributes;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight client-side telemetry service with an event log dialog
- expose new Ctrl+L shortcuts in the planning UI to toggle a metrics HUD and open the event log
- track conflict lifecycle timings and user actions to feed the HUD counters

## Testing
- `mvn -pl client -am -DskipTests compile` *(fails: unable to download org.springframework.boot:spring-boot-dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d415d7548330bbcd6f8a50833424